### PR TITLE
Navigateのlabelの位置を整える

### DIFF
--- a/components/Navigate.js
+++ b/components/Navigate.js
@@ -101,6 +101,13 @@ const Navigate = (props) => {
                                       </p>
                                     </li>
                                   );
+                                } else {
+                                  return (
+                                    <li
+                                      key={j}
+                                      className="label_list__item__null"
+                                    ></li>
+                                  );
                                 }
                               })}
                             </ul>

--- a/styles/_index.scss
+++ b/styles/_index.scss
@@ -156,6 +156,9 @@
                 border-radius: 8px;
                 background-color: $white;
               }
+              &__null {
+                margin: 120px 0 0 0;
+              }
             }
           }
         }


### PR DESCRIPTION
Navigateの2つ目のパスのlabelがずれていたので、ダミーのリストを入れた
スタイルは適当