### PR TITLE
config関連のapiのターゲット先を変更[main]

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -25,7 +25,7 @@ const Home = () => {
     const fetchApi = async () => {
       const promises = await Promise.all([
         axios.get(`${process.env.NEXT_PUBLIC_API_ENDOPOINT}/config/dataset`),
-        axios.get(`${process.env.NEXT_PUBLIC_API_ENDOPOINT}/config/database`),
+        axios.get(`${process.env.NEXT_PUBLIC_API_ENDOPOINT}/config/relation`),
         axios.get(
           `${process.env.NEXT_PUBLIC_API_ENDOPOINT}/config/descriptions`
         ),


### PR DESCRIPTION
## 注意
main向けの変更です
- mainに追加された後にdevelopへ組み込みます

## 概要
apiのurlが`/config/database/`から`/config/relation/`に変更されたことによるフロントの変更

##### その他
datasetの変更による影響はありませんでした