### PR TITLE
[hotfix]idが空の時にsubmitするとエラーが発生する

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -221,8 +221,8 @@ const Home = () => {
     if (candidates.length > 0) {
       setDatabaseNodesList([candidates]);
       setRoute([]);
-      return candidates;
     }
+    return candidates;
   };
 
   const clearExplore = () => {


### PR DESCRIPTION
# バグ修正
idが空の状態でsubmitすると配列のlengthがないと怒られてエラーが発生してしまっていた
keepRoute関連

## 影響範囲
develop及びその派生
- main関連のブランチでは発生しなかった