### PR TITLE
変換エラーの時にresultmodalへのiconを表示しない

### DIFF
--- a/components/Explore.js
+++ b/components/Explore.js
@@ -126,9 +126,7 @@ const Explore = (props) => {
                                     <div
                                       id={`to${i}-${v.name}`}
                                       className={`radio green ${
-                                        i === 0 ||
-                                        (v.target > 0 &&
-                                          (!v.message || v.message !== "ERROR"))
+                                        i === 0 || v.target > 0
                                           ? null
                                           : "not_found"
                                       }`}
@@ -143,10 +141,7 @@ const Explore = (props) => {
                                             props.route[i].name === v.name
                                         )}
                                         onChange={() => selectDatabase(v, i)}
-                                        disabled={
-                                          i > 0 &&
-                                          (!v.target || v.message === "ERROR")
-                                        }
+                                        disabled={i > 0 && !v.target}
                                       />
                                       <label
                                         htmlFor={`result${i}-${j}`}

--- a/pages/index.js
+++ b/pages/index.js
@@ -113,8 +113,8 @@ const Home = () => {
             candidates.push({
               name,
               category: dbCatalogue[name].category,
-              source: 1,
-              target: 1,
+              source: 0,
+              target: 0,
               link: dbConfig[`${r.name}-${name}`].link.forward.label,
               results: [],
             });
@@ -130,8 +130,8 @@ const Home = () => {
             candidates.push({
               name,
               category: dbCatalogue[name].category,
-              source: 1,
-              target: 1,
+              source: 0,
+              target: 0,
               link: dbConfig[`${name}-${r.name}`].link.reverse.label,
               results: [],
             });
@@ -171,6 +171,8 @@ const Home = () => {
               _v.target = count.target;
             }
           } else {
+            // targetが0のままでは変換が0個と同じ扱いになってしまうため1以上にしておく
+            _v.target = 1;
             _v.message = `${_v.results.length}+`;
           }
         } else {


### PR DESCRIPTION
変換エラーの時にresultmodalとhandleiddownloadへのiconを表示しない
toomanyであれば表示する

そのためにmessageを直接参照するわけではなく、targetが0より大きいかどうかも判定に含めた