### PR TITLE
prefix選択プルダウンの表示を変更する

### DIFF
--- a/components/ResultModalAction.js
+++ b/components/ResultModalAction.js
@@ -391,13 +391,13 @@ const ResultModalAction = (props) => {
                         onChange={(e) => handleSelectPrefix(e)}
                         value={lineMode[v.index]}
                       >
-                        <option value="id">IDs</option>
+                        <option value="id">ID</option>
                         {prefixList[v.index].map((w) => (
                           <option key={w} value={w}>
-                            Prefix ({w})
+                            ID ({w})
                           </option>
                         ))}
-                        <option value="url">URLs</option>
+                        <option value="url">URL</option>
                       </select>
                     </fieldset>
                   </th>


### PR DESCRIPTION
## 内容
prefix選択プルダウンの表示を変更した
以下にGOの場合の例を示す
- ID
- ID (GO:%s)
- ID (GO_%s)
- URL
<img width="115" alt="image" src="https://user-images.githubusercontent.com/52652603/200205643-2069ce3d-9fad-4544-a2f9-d8db17ffa33e.png">
