### PR TITLE
html内のkeyの重複を修正する

### DIFF
--- a/components/Explore.js
+++ b/components/Explore.js
@@ -224,7 +224,7 @@ const Explore = (props) => {
                           className={
                             i === 0 ? "result_list first" : "result_list"
                           }
-                          key={1}
+                          key={2}
                         >
                           {nodes.map((v, j) => {
                             const isActionButtonVisible =


### PR DESCRIPTION
キーの重複エラーが発生しているためにconsoleが埋まってしまい、`console.log`による値の確認が困難であったため修正。