### PR TITLE
nameでsortする際に大文字と小文字を区別しない

### DIFF
--- a/components/Explore.js
+++ b/components/Explore.js
@@ -35,10 +35,14 @@ const Explore = (props) => {
         sortModeOrders.push(sortModeOrderList[i]);
       } else {
         const sorted = v.sort((a, b) => {
-          if (datasetConfig[a.name].label < datasetConfig[b.name].label) {
+          if (
+            datasetConfig[a.name].label.toLowerCase() <
+            datasetConfig[b.name].label.toLowerCase()
+          ) {
             return -1;
           } else if (
-            datasetConfig[a.name].label > datasetConfig[b.name].label
+            datasetConfig[a.name].label.toLowerCase() >
+            datasetConfig[b.name].label.toLowerCase()
           ) {
             return 1;
           } else {
@@ -115,9 +119,15 @@ const Explore = (props) => {
     const nodesListCopy = nodesList.slice();
     if (mode === "name") {
       nodesListCopy[i].sort((a, b) => {
-        if (datasetConfig[a.name].label < datasetConfig[b.name].label) {
+        if (
+          datasetConfig[a.name].label.toLowerCase() <
+          datasetConfig[b.name].label.toLowerCase()
+        ) {
           return n * -1;
-        } else if (datasetConfig[a.name].label > datasetConfig[b.name].label) {
+        } else if (
+          datasetConfig[a.name].label.toLowerCase() >
+          datasetConfig[b.name].label.toLowerCase()
+        ) {
           return n * 1;
         }
       });


### PR DESCRIPTION
nameによるソートがlabelの大文字小文字の影響を受けており、先頭が小文字のものが最後に表示されてしまっていたので、すべて小文字に揃えた状態で比較するように変更しました。