### PR TITLE
swaggerドキュメントを再表示する

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-markdown": "9.0.1",
     "react-select": "5.8.0",
     "react-use": "17.5.0",
+    "swagger-ui-react": "5.11.8",
     "swr": "2.2.5"
   },
   "devDependencies": {
@@ -31,6 +32,7 @@
     "@types/papaparse": "5.3.14",
     "@types/react": "18.2.60",
     "@types/react-dom": "18.2.19",
+    "@types/swagger-ui-react": "4.18.3",
     "eslint": "8.57.0",
     "eslint-config-next": "14.1.0",
     "eslint-config-prettier": "9.1.0",

--- a/src/pages/apidoc.tsx
+++ b/src/pages/apidoc.tsx
@@ -1,0 +1,10 @@
+import SwaggerUI from "swagger-ui-react";
+import "swagger-ui-react/swagger-ui.css";
+
+import oas from "@/../swagger/oas.json";
+
+const Apidoc = () => {
+  return <SwaggerUI spec={oas} />;
+};
+
+export default Apidoc;

--- a/swagger/oas.json
+++ b/swagger/oas.json
@@ -1,8353 +1,8279 @@
 {
-    "openapi": "3.0.1",
-    "info": {
-      "title": "TogoID API",
-      "version": "2.0.0"
+  "openapi": "3.0.0",
+  "info": {
+    "title": "TogoID API",
+    "version": "2.0.1"
+  },
+  "servers": [
+    {
+      "url": "https://api.togoid.dbcls.jp"
+    }
+  ],
+  "tags": [
+    {
+      "name": "convert"
     },
-    "host": "api.togoid.dbcls.jp",
-    "schemes": [
-      "https"
-    ],
-    "produces": [
-      "application/json"
-    ],
-    "tags": [
-      {
-        "name": "convert"
-      },
-      {
-        "name": "count"
-      },
-      {
-        "name": "config"
-      }
-    ],
-    "paths": {
-      "/convert": {
-        "get": {
-          "tags": [
-            "convert"
-          ],
-          "summary": "Convert IDs",
-          "operationId": "convertId",
-          "parameters": [
-            {
-              "name": "ids",
-              "in": "query",
+    {
+      "name": "count"
+    },
+    {
+      "name": "config"
+    }
+  ],
+  "paths": {
+    "/convert": {
+      "get": {
+        "tags": ["convert"],
+        "summary": "Convert IDs",
+        "operationId": "convertId",
+        "parameters": [
+          {
+            "name": "ids",
+            "in": "query",
+            "description": "A comma-separated list of source IDs.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "route",
+            "in": "query",
+            "description": "A comma-separated list of datasets, starts with the source dataset and ends with the target dataset.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "report",
+            "in": "query",
+            "description": "The output type can be selected from the following: 'target' (includes target IDs only), 'pair' (includes source and target IDs), 'all' (all converted IDs including source, target, and intermediate IDs of the route), or 'full' (all IDs including unconverted IDs).",
+            "schema": {
               "type": "string",
-              "description": "A comma-separated list of source IDs.",
-              "required": true
-            },
-            {
-              "name": "route",
-              "in": "query",
+              "enum": ["all", "pair", "target", "full"],
+              "default": "target"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "description": "The output format can be selected from 'tsv', 'csv', or 'json'.",
+            "schema": {
               "type": "string",
-              "description": "A comma-separated list of datasets, starts with the source dataset and ends with the target dataset.",
-              "required": true
-            },
-            {
-              "name": "report",
-              "in": "query",
-              "type": "string",
-              "enum": [
-                "all",
-                "pair",
-                "target",
-                "full"
-              ],
-              "default": "target",
-              "description": "The output type can be selected from the following: 'target' (includes target IDs only), 'pair' (includes source and target IDs), 'all' (all converted IDs including source, target, and intermediate IDs of the route), or 'full' (all IDs including unconverted IDs)."
-            },
-            {
-              "name": "format",
-              "in": "query",
-              "type": "string",
-              "enum": [
-                "csv",
-                "tsv",
-                "json"
-              ],
-              "default": "json",
-              "description": "The output format can be selected from 'tsv', 'csv', or 'json'."
-            },
-            {
-              "name": "limit",
-              "in": "query",
+              "enum": ["csv", "tsv", "json"],
+              "default": "json"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "The maximum number of results to be returned.",
+            "schema": {
               "type": "integer",
-              "default": 10000,
               "maximum": 10000,
-              "description": "The maximum number of results to be returned."
-            },
-            {
-              "name": "offset",
-              "in": "query",
+              "default": 10000
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "The position to start after the specified number of results.",
+            "schema": {
               "type": "integer",
-              "default": 0,
-              "description": "The position to start after the specified number of results."
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "successful operation",
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "ids": {
-                    "type": "string",
-                    "example": [
-                      "26199",
-                      "38937",
-                      "14027",
-                      "21498",
-                      "18185",
-                      "1314",
-                      "25960",
-                      "2206",
-                      "22224",
-                      "19741"
-                    ]
-                  },
-                  "route": {
-                    "type": "string",
-                    "example": [
-                      "hgnc",
-                      "ensembl_gene"
-                    ]
-                  },
-                  "result": {
-                    "type": "string",
-                    "example": [
-                      "ENSG00000100364",
-                      "ENSG00000154719",
-                      "ENSG00000116285",
-                      "ENSG00000179454",
-                      "ENSG00000085978",
-                      "ENSG00000081052",
-                      "ENSG00000006459",
-                      "ENSG00000198088",
-                      "ENSG00000134152",
-                      "ENSG00000284140"
-                    ]
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "Bad request"
+              "default": 0
             }
           }
-        }
-      },
-      "/count/{source}-{target}": {
-        "get": {
-          "tags": [
-            "count"
-          ],
-          "summary": "Count IDs",
-          "operationId": "countId",
-          "parameters": [
-            {
-              "name": "source",
-              "in": "path",
-              "type": "string",
-              "description": "A key from https://github.com/dbcls/togoid-config/blob/main/config/dataset.yaml",
-              "required": true
-            },
-            {
-              "name": "target",
-              "in": "path",
-              "type": "string",
-              "description": "A key from https://github.com/dbcls/togoid-config/blob/main/config/dataset.yaml",
-              "required": true
-            },
-            {
-              "name": "ids",
-              "in": "query",
-              "type": "string",
-              "description": "List IDs separated by commas",
-              "required": true
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "successful operation",
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "source": {
-                    "type": "string",
-                    "example": 2
-                  },
-                  "target": {
-                    "type": "string",
-                    "example": 2
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "Bad request"
-            }
-          }
-        }
-      },
-      "/config/dataset": {
-        "get": {
-          "tags": [
-            "config"
-          ],
-          "summary": "Get all dataset config",
-          "operationId": "getAllDataset",
-          "responses": {
-            "200": {
-              "description": "successful operation",
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "affy_probeset": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "Affymetrix probeset"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>\\d{3,}(?:_[a-z])?_at)$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/affy.probeset/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "FIXME"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Probe"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "1553582_a_at",
-                            "211531_x_at",
-                            "202573_at",
-                            "201640_x_at",
-                            "205117_at",
-                            "201017_at",
-                            "205099_s_at",
-                            "200614_at",
-                            "201895_at",
-                            "202666_s_at"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "bioproject": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "BioProject"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>PRJ[DEN][A-Z]\\d+)$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/bioproject/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00476"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Project"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "PRJDB575",
-                            "PRJDB1880",
-                            "PRJDB478",
-                            "PRJDA45949",
-                            "PRJEB6285",
-                            "PRJEA28961",
-                            "PRJEB2222",
-                            "PRJNA30641",
-                            "PRJNA68235",
-                            "PRJNA42549"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "biosample": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "BioSample"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>SAM[NED]\\w?\\d+)$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/biosample/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc01983"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Sample"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "SAMD00003683",
-                            "SAMD00006315",
-                            "SAMD00003741",
-                            "SAMD00011226",
-                            "SAMN13091859",
-                            "SAMN05877962",
-                            "SAMN05877838",
-                            "SAMEA104232303",
-                            "SAMEA4760552",
-                            "SAMEA1572228"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "ccds": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "Consensus CDS"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>CCDS\\d+)(?:\\.\\d+)?$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/ccds/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00023"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Gene"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "CCDS1471",
-                            "CCDS10913",
-                            "CCDS14790",
-                            "CCDS35175",
-                            "CCDS2395",
-                            "CCDS58412",
-                            "CCDS55555",
-                            "CCDS34401",
-                            "CCDS41889",
-                            "CCDS9052"
-                          ],
-                          [
-                            "CCDS1471.1",
-                            "CCDS10913.1",
-                            "CCDS14790.1",
-                            "CCDS35175.2",
-                            "CCDS2395.1",
-                            "CCDS58412.1",
-                            "CCDS55555.1",
-                            "CCDS34401.2",
-                            "CCDS41889.1",
-                            "CCDS9052.1"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "chebi": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "ChEBI compound"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?:CHEBI[:_])?(?<id>\\d+)$"
-                      },
-                      "format": {
-                        "type": "string",
-                        "example": [
-                          "%s",
-                          "CHEBI:%s",
-                          "CHEBI_%"
-                        ]
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://purl.obolibrary.org/obo/CHEBI_"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00027"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Compound"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "84824",
-                            "40167",
-                            "32807",
-                            "87666",
-                            "57524",
-                            "64860",
-                            "94440",
-                            "18005",
-                            "4806",
-                            "50158"
-                          ],
-                          [
-                            "CHEBI:84824",
-                            "CHEBI:40167",
-                            "CHEBI:32807",
-                            "CHEBI:87666",
-                            "CHEBI:57524",
-                            "CHEBI:64860",
-                            "CHEBI:94440",
-                            "CHEBI:18005",
-                            "CHEBI:4806",
-                            "CHEBI:50158"
-                          ],
-                          [
-                            "CHEBI_84824",
-                            "CHEBI_40167",
-                            "CHEBI_32807",
-                            "CHEBI_87666",
-                            "CHEBI_57524",
-                            "CHEBI_64860",
-                            "CHEBI_94440",
-                            "CHEBI_18005",
-                            "CHEBI_4806",
-                            "CHEBI_50158"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "chembl_compound": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "ChEMBL compound"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>CHEMBL\\d+)$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/chembl.compound/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc02555"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Compound"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "CHEMBL121649",
-                            "CHEMBL190334",
-                            "CHEMBL3103282",
-                            "CHEMBL69329",
-                            "CHEMBL2105131",
-                            "CHEMBL2177390",
-                            "CHEMBL3091820",
-                            "CHEMBL1200335",
-                            "CHEMBL3094412",
-                            "CHEMBL67367"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "chembl_target": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "ChEMBL target"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>CHEMBL\\d+)$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/chembl.target/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc02555"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Protein"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "CHEMBL2788",
-                            "CHEMBL3091264",
-                            "CHEMBL3831324",
-                            "CHEMBL5524",
-                            "CHEMBL5597",
-                            "CHEMBL3983",
-                            "CHEMBL4187",
-                            "CHEMBL3391681",
-                            "CHEMBL5135",
-                            "CHEMBL1255130"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "civic_gene": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "CIVIC gene"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>\\d+)$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://civic.genome.wustl.edu/links/genes/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc02558"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Gene"
-                      }
-                    }
-                  },
-                  "clinvar": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "ClinVar variant"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(VCV0*)?(?<id>(\\d{1,9}))$"
-                      },
-                      "format": {
-                        "type": "string",
-                        "example": [
-                          "%s",
-                          "VCV%09d"
-                        ]
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/clinvar/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc01514"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Variant"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "658761",
-                            "619209",
-                            "745342",
-                            "11955",
-                            "731668",
-                            "724289",
-                            "725734",
-                            "743127",
-                            "789913",
-                            "5302"
-                          ],
-                          [
-                            "VCV000658761",
-                            "VCV000619209",
-                            "VCV000745342",
-                            "VCV000011955",
-                            "VCV000731668",
-                            "VCV000724289",
-                            "VCV000725734",
-                            "VCV000743127",
-                            "VCV000789913",
-                            "VCV000005302"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "dbsnp": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "dbSNP"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>rs\\d+)$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/dbsnp/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00206"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Variant"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "rs746303788",
-                            "rs1407020249",
-                            "rs374003162",
-                            "rs4647297",
-                            "rs549539526",
-                            "rs1387864740",
-                            "rs1177577242",
-                            "rs769848663",
-                            "rs16961655",
-                            "rs79135400"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "dgidb": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "DGIdb"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "FIXME"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc02562"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Interaction"
-                      }
-                    }
-                  },
-                  "doid": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "Disease ontology"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^DO(?:ID)?[:_](?<id>\\d+)$"
-                      },
-                      "format": {
-                        "type": "string",
-                        "example": [
-                          "DO:%s",
-                          "DOID:%s",
-                          "DOID_%s"
-                        ]
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://purl.obolibrary.org/obo/DOID_"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00261"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Disease"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "DO:9036",
-                            "DO:3159",
-                            "DO:10964",
-                            "DO:12698",
-                            "DO:0060459",
-                            "DO:11840",
-                            "DO:11339",
-                            "DO:914",
-                            "DO:9945",
-                            "DO:1407"
-                          ],
-                          [
-                            "DOID:9036",
-                            "DOID:3159",
-                            "DOID:10964",
-                            "DOID:12698",
-                            "DOID:0060459",
-                            "DOID:11840",
-                            "DOID:11339",
-                            "DOID:914",
-                            "DOID:9945",
-                            "DOID:1407"
-                          ],
-                          [
-                            "DOID_9036",
-                            "DOID_3159",
-                            "DOID_10964",
-                            "DOID_12698",
-                            "DOID_0060459",
-                            "DOID_11840",
-                            "DOID_11339",
-                            "DOID_914",
-                            "DOID_9945",
-                            "DOID_1407"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "drugbank": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "DrugBank"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>DB\\d{5})$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/drugbank/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc01071"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Compound"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "DB15589",
-                            "DB13471",
-                            "DB05830",
-                            "DB07423",
-                            "DB07074",
-                            "DB08912",
-                            "DB02908",
-                            "DB05088",
-                            "DB05229",
-                            "DB08910"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "ec": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "Enzyme nomenclature"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?:EC:)?(?<id>\\d+\\.(?:(?:-\\.-\\.-)|\\d+\\.(?:(?:-\\.-)|\\d+\\.(?:-|n?\\d+))))$"
-                      },
-                      "format": {
-                        "type": "string",
-                        "example": [
-                          "%s",
-                          "EC:%s"
-                        ]
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/ec-code/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc01883"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Function"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "1.6.3.1",
-                            "2.4.1.353",
-                            "1.1.1.288",
-                            "1.5.1.2",
-                            "3.1.1.71",
-                            "1.3.1.31",
-                            "3.5.1.29",
-                            "1.16.1.1",
-                            "3.1.3.48",
-                            "2.3.1.138"
-                          ],
-                          [
-                            "EC:1.6.3.1",
-                            "EC:2.4.1.353",
-                            "EC:1.1.1.288",
-                            "EC:1.5.1.2",
-                            "EC:3.1.1.71",
-                            "EC:1.3.1.31",
-                            "EC:3.5.1.29",
-                            "EC:1.16.1.1",
-                            "EC:3.1.3.48",
-                            "EC:2.3.1.138"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "ena": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "ENA"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?:ena\\.embl:)?(?<id>[A-Z]+[0-9]+)(?:\\.\\d+)?$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/ena.embl/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00432"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Gene"
-                      }
-                    }
-                  },
-                  "ensembl_gene": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "Ensembl gene"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?:(?:(?<id1>ENS[A-Z]*G\\d{11})(?:\\.\\d+)?)|(?<id2>FBgn\\d{7})|(?:(?<id3>MGP_[A-Za-z0-9]+_G\\d{7})(?:\\.\\d+)?)|(?<id4>LRG_\\d+)|(?<id5>WBGene\\d{8})|(?<id6>Y[A-Z]{2}\\d{3}[A-Z](?:-[A-Z])?)|(?<id7>Q\\d{4})|(?<id8>[A-Z]{3}\\d{1,3}(?:-\\d)?)|(?<id9>snR\\d+-?[A-Za-z]?)|(?<id10>t[A-Z]\\([ACGUX]{3}\\)[A-Z]\\d?))$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/ensembl/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00054"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Gene"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "ENSG00000186283",
-                            "ENSAMEG00000018238",
-                            "ENSG00000167916",
-                            "ENSG00000213417",
-                            "ENSG00000133328",
-                            "ENSG00000274404",
-                            "ENSG00000184363",
-                            "FBgn0021742",
-                            "FBgn0030057",
-                            "FBgn0265139"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "ensembl_protein": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "Ensembl protein"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?:(?:(?<id1>ENS[A-Z]*P\\d{11})(?:\\.\\d+)?)|(?<id2>FBpp\\d{7})|(?:(?<id3>MGP_[A-Za-z0-9]+_P\\d{7})(?:\\.\\d+)?)|(?<id4>LRG_\\d+p\\d+(?:-\\d)?)|(?<id5>(?:[A-Za-z0-9][A-Za-z0-9_]+)\\.t?\\d+[a-z]?(?:\\.\\d+)?)|(?<id6>Y[A-Z]{2}\\d{3}[A-Z](?:-[A-Z])?)|(?<id7>Q\\d{4}))$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/ensembl/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00054"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Protein"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "ENSP00000365411",
-                            "ENSP00000420674",
-                            "ENSAZOP00000020796",
-                            "FBpp0070277",
-                            "FBpp0070535",
-                            "ENSAZOP00000019433",
-                            "ENSP00000372042",
-                            "ENSAZOP00000017910",
-                            "ENSP00000370977",
-                            "ENSP00000481894"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "ensembl_transcript": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "Ensembl transcript"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?:(?:(?<id1>ENS[A-Z]*T\\d{11})(?:\\.\\d+)?)|(?<id2>FBtr\\d{7})|(?:(?<id3>MGP_[A-Za-z0-9]+_T\\d{7})(?:\\.\\d+)?)|(?<id4>LRG_\\d+t\\d+(?:-\\d)?)|(?<id5>(?:[A-Za-z0-9][A-Za-z0-9_]+)\\.t?\\d+[a-z]?(?:\\.\\d+)?)|(?<id6>Y[A-Z]{2}\\d{3}[A-Z](?:-[A-Z])?(?:_[a-z]{1,3}RNA)?)|(?<id7>Q\\d{4}_[a-z]{1,3}RNA)|(?<id8>[A-Z]{3}\\d{1,3}(?:-\\d)?_[a-z]{1,3}RNA)|(?<id9>snR\\d+-?[A-Za-z]?_sno?RNA)|(?<id10>t[A-Z]\\([ACGUX]{3}\\)[A-Z]\\d?_tRNA))$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/ensembl/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00054"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Transcript"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "ENST00000638000",
-                            "ENST00000307864",
-                            "ENSTRUT00000006732",
-                            "ENSAMET00000021072",
-                            "ENSAZOT00000021040",
-                            "ENST00000622541",
-                            "ENST00000462612",
-                            "ENSBTAT00000072441",
-                            "ENSAZOT00000005048",
-                            "ENST00000475822"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "glytoucan": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "GlyTouCan"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>G[0-9]{5}[A-Z]{2})$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/glytoucan/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc01535"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Glycan"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "G88006IV",
-                            "G53085MI",
-                            "G17896UT",
-                            "G50341PG",
-                            "G19379ID",
-                            "G08110WX",
-                            "G70101JE",
-                            "G45504EY",
-                            "G81263BG",
-                            "G02815KT"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "go": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "Gene ontology"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^GO[:_](?<id>\\d{7})$"
-                      },
-                      "format": {
-                        "type": "string",
-                        "example": [
-                          "GO:%s",
-                          "GO_%s"
-                        ]
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://purl.obolibrary.org/obo/GO_"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00074"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Function"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "GO:0005643",
-                            "GO:0097110",
-                            "GO:0097225",
-                            "GO:0052855",
-                            "GO:2000012",
-                            "GO:0042921",
-                            "GO:0019774",
-                            "GO:0085018",
-                            "GO:0009508",
-                            "GO:0046470"
-                          ],
-                          [
-                            "GO_0005643",
-                            "GO_0097110",
-                            "GO_0097225",
-                            "GO_0052855",
-                            "GO_2000012",
-                            "GO_0042921",
-                            "GO_0019774",
-                            "GO_0085018",
-                            "GO_0009508",
-                            "GO_0046470"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "hgnc": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "HGNC"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?:(?:HGNC|hgnc):)?(?<id>\\d{1,5})$"
-                      },
-                      "format": {
-                        "type": "string",
-                        "example": [
-                          "%s",
-                          "HGNC:%s",
-                          "hgnc:%s"
-                        ]
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/hgnc/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc01774"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Gene"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "26199",
-                            "38937",
-                            "14027",
-                            "21498",
-                            "18185",
-                            "1314",
-                            "25960",
-                            "2206",
-                            "22224",
-                            "19741"
-                          ],
-                          [
-                            "HGNC:26199",
-                            "HGNC:38937",
-                            "HGNC:14027",
-                            "HGNC:21498",
-                            "HGNC:18185",
-                            "HGNC:1314",
-                            "HGNC:25960",
-                            "HGNC:2206",
-                            "HGNC:22224",
-                            "HGNC:19741"
-                          ],
-                          [
-                            "hgnc:26199",
-                            "hgnc:38937",
-                            "hgnc:14027",
-                            "hgnc:21498",
-                            "hgnc:18185",
-                            "hgnc:1314",
-                            "hgnc:25960",
-                            "hgnc:2206",
-                            "hgnc:22224",
-                            "hgnc:19741"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "hgnc_symbol": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "HGNC gene symbol"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>[A-Za-z0-9_\\-]+\\@?)$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/hgnc.symbol/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc01774"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Gene"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "MBNL2",
-                            "RGS20",
-                            "LINC02011",
-                            "IGHV1-14",
-                            "SH3RF2",
-                            "SPATA13",
-                            "HNRNPCP10",
-                            "LINC00334",
-                            "TMEM241",
-                            "RN7SL753P"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "hmdb": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "HMDB"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?:hmdb:)?(?<id>HMDB\\d+)$"
-                      },
-                      "format": {
-                        "type": "string",
-                        "example": [
-                          "%s",
-                          "hmdb:%s"
-                        ]
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/hmdb/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00909"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Compound"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "HMDB0029433",
-                            "HMDB0015609",
-                            "HMDB0000042",
-                            "HMDB0002360",
-                            "HMDB0003345",
-                            "HMDB0003550",
-                            "HMDB0036769",
-                            "HMDB0000935",
-                            "HMDB0002755",
-                            "HMDB0004369"
-                          ],
-                          [
-                            "hmdb:HMDB0029433",
-                            "hmdb:HMDB0015609",
-                            "hmdb:HMDB0000042",
-                            "hmdb:HMDB0002360",
-                            "hmdb:HMDB0003345",
-                            "hmdb:HMDB0003550",
-                            "hmdb:HMDB0036769",
-                            "hmdb:HMDB0000935",
-                            "hmdb:HMDB0002755",
-                            "hmdb:HMDB0004369"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "homologene": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "HomoloGene"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>\\d+)$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/homologene/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00101"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Ortholog"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "117",
-                            "17",
-                            "6",
-                            "142",
-                            "55",
-                            "132",
-                            "61",
-                            "109",
-                            "137",
-                            "134"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "hp": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "Human Phenotype Ontology"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^HP[:_](?<id>\\d{7})$"
-                      },
-                      "format": {
-                        "type": "string",
-                        "example": [
-                          "HP:%s",
-                          "HP_%s"
-                        ]
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://purl.obolibrary.org/obo/HP_"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc02559"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Disease"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "HP:0001947",
-                            "HP:0031592",
-                            "HP:0012085",
-                            "HP:0000956",
-                            "HP:0025238",
-                            "HP:0002861",
-                            "HP:0001680",
-                            "HP:0004417",
-                            "HP:0001701",
-                            "HP:0025084"
-                          ],
-                          [
-                            "HP_0001947",
-                            "HP_0031592",
-                            "HP_0012085",
-                            "HP_0000956",
-                            "HP_0025238",
-                            "HP_0002861",
-                            "HP_0001680",
-                            "HP_0004417",
-                            "HP_0001701",
-                            "HP_0025084"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "human_protein_atlas": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "Human Protein Atlas"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>ENSG\\d{11})$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://www.proteinatlas.org/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00905"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Protein"
-                      }
-                    }
-                  },
-                  "inchi_key": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "InChIKey"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>[A-Z]{14}\\-[A-Z]{10}(\\-[A-Z])?)$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "https://identifiers.org/inchikey/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "FIXME"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Compound"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "RYYVLZVUVIJVGH-UHFFFAOYSA-N",
-                            "RZWGTXHSYZGXKF-UHFFFAOYSA-N",
-                            "RQQIIXFYTHWFKW-ZETCQYMHSA-N",
-                            "RALAARQREFCZJO-UHFFFAOYSA-N",
-                            "HVFRJJDZWVSUIB-UHFFFAOYSA-N",
-                            "KVNZVXVZQFTXNA-UHFFFAOYSA-N",
-                            "KVQUJTYBWCGJRS-UHFFFAOYSA-N",
-                            "AFGLQVAJWVTAJT-UHFFFAOYSA-N",
-                            "LHISABQPMWXWCC-UHFFFAOYSA-N",
-                            "ZSXCHLJCWRSMMS-UHFFFAOYSA-N"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "insdc": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "GenBank/ENA/DDBJ"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?:insdc:)?(?<id>[A-Z]\\d{5}|[A-Z]{2}\\d{6}|[A-Z]{4}\\d{8}|[A-J][A-Z]{2}\\d{5}|[A-Z]{4,}\\d{9})(?:\\.\\d+)?$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/insdc/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc02567"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Gene"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "U10991",
-                            "AF116914",
-                            "AK056978",
-                            "DQ440258",
-                            "U91725",
-                            "AY301270",
-                            "U32907",
-                            "AY261360",
-                            "AK001332",
-                            "U13261"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "intact": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "IntAct"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>EBI\\-[0-9]+)$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/intact/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00507"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Interaction"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "EBI-7947422",
-                            "EBI-15714708",
-                            "EBI-16225271",
-                            "EBI-4406290",
-                            "EBI-9026465",
-                            "EBI-6403471",
-                            "EBI-1113651",
-                            "EBI-562824",
-                            "EBI-9014072",
-                            "EBI-1784742"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "interpro": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "InterPro"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>IPR\\d{6})$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/interpro/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00108"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Domain"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "IPR038152",
-                            "IPR040448",
-                            "IPR036748",
-                            "IPR034266",
-                            "IPR005479",
-                            "IPR036365",
-                            "IPR000174",
-                            "IPR001334",
-                            "IPR000731",
-                            "IPR001767"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "kegg_compound": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "KEGG Compound"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>C\\d+)$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/kegg.compound/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00814"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Compound"
-                      }
-                    }
-                  },
-                  "kegg_disease": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "KEGG Disease"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^KEGG:H(?<id>\\d+)$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/kegg.disease/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00813"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Disease"
-                      }
-                    }
-                  },
-                  "kegg_drug": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "KEGG Drug"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>D\\d+)$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/kegg.drug/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00812"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Drug"
-                      }
-                    }
-                  },
-                  "kegg_genes": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "KEGG Genes"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^\\w+:[\\w\\d\\.-]*$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/kegg.genes/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00532"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Gene, Protein"
-                      }
-                    }
-                  },
-                  "kegg_orthology": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "KEGG Orthology"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>K\\d+)$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/kegg.orthology/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00817"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Ortholog"
-                      }
-                    }
-                  },
-                  "kegg_pathway": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "KEGG Pathway"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>\\w{2,4}\\d{5})$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/kegg.pathway/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00118"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Pathway"
-                      }
-                    }
-                  },
-                  "kegg_reaction": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "KEGG Reaction"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>R\\d+)$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/kegg.reaction/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00818"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Interaction"
-                      }
-                    }
-                  },
-                  "lrg": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "LRG"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>LRG_\\d+)$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/lrg/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc02566"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Gene"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "LRG_41",
-                            "LRG_356",
-                            "LRG_147",
-                            "LRG_660",
-                            "LRG_498",
-                            "LRG_364",
-                            "LRG_203",
-                            "LRG_162",
-                            "LRG_1271",
-                            "LRG_884"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "mbgd_gene": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "MBGD gene"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>[a-z0-9]+:[A-Z0-9_\\.-]+)$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://mbgd.genome.ad.jp/rdf/resource/gene/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00130"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Gene"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "ash:AL1_RS04670",
-                            "ash:AL1_RS08245",
-                            "ash:AL1_RS02870",
-                            "ash:AL1_RS06610",
-                            "ash:AL1_RS06290",
-                            "ash:AL1_RS07260",
-                            "ash:AL1_RS08410",
-                            "ash:AL1_RS01705",
-                            "ash:AL1_RS02510",
-                            "ash:AL1_RS07245"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "mbgd_organism": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "MBGD organism"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>[a-z0-9]+)$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://mbgd.genome.ad.jp/rdf/resource/organism/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00130"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Taxonomy"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "lac",
-                            "pfl",
-                            "cou",
-                            "bvn",
-                            "btd",
-                            "ctjt",
-                            "sha",
-                            "lmoj",
-                            "dpi",
-                            "arp"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "meddra": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "MedDRA"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?:(?:MedDRA|meddra):)?(?<id>\\d+)$"
-                      },
-                      "format": {
-                        "type": "string",
-                        "example": [
-                          "%s",
-                          "MedDRA:%s",
-                          "meddra:%s"
-                        ]
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/meddra/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc02564"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Disease"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "10008033",
-                            "10027710",
-                            "10062506",
-                            "10040493",
-                            "10013611",
-                            "10065857",
-                            "10063143",
-                            "10022599",
-                            "10042342",
-                            "10047883"
-                          ],
-                          [
-                            "MedDRA:10008033",
-                            "MedDRA:10027710",
-                            "MedDRA:10062506",
-                            "MedDRA:10040493",
-                            "MedDRA:10013611",
-                            "MedDRA:10065857",
-                            "MedDRA:10063143",
-                            "MedDRA:10022599",
-                            "MedDRA:10042342",
-                            "MedDRA:10047883"
-                          ],
-                          [
-                            "meddra:10008033",
-                            "meddra:10027710",
-                            "meddra:10062506",
-                            "meddra:10040493",
-                            "meddra:10013611",
-                            "meddra:10065857",
-                            "meddra:10063143",
-                            "meddra:10022599",
-                            "meddra:10042342",
-                            "meddra:10047883"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "medgen": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "MedGen"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>CN?\\d{4,7})$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/medgen/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc02560"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Disease"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "C0264897",
-                            "C0028860",
-                            "C0018818",
-                            "C1848392",
-                            "C0006389",
-                            "C0020517",
-                            "C0000364",
-                            "CN227118",
-                            "CN203043",
-                            "CN292950"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "mesh": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "MeSH"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>[CD]\\d{6,9})$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/mesh/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00132"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Disease"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "D002065",
-                            "C562829",
-                            "C566582",
-                            "D010623",
-                            "D003327",
-                            "D001715",
-                            "D000453",
-                            "D010260",
-                            "C537322",
-                            "C563418"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "mgi": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "MGI"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?:MGI|mgi):(?<id>\\d{5,})$"
-                      },
-                      "format": {
-                        "type": "string",
-                        "example": [
-                          "MGI:%s",
-                          "mgi:%s"
-                        ]
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/mgi/MGI:"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00135"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Gene"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "MGI:2387184",
-                            "MGI:1920977",
-                            "MGI:2442415",
-                            "MGI:1098644",
-                            "MGI:1196250",
-                            "MGI:1914934",
-                            "MGI:1914238",
-                            "MGI:1919300",
-                            "MGI:1914807",
-                            "MGI:2145261"
-                          ],
-                          [
-                            "mgi:2387184",
-                            "mgi:1920977",
-                            "mgi:2442415",
-                            "mgi:1098644",
-                            "mgi:1196250",
-                            "mgi:1914934",
-                            "mgi:1914238",
-                            "mgi:1919300",
-                            "mgi:1914807",
-                            "mgi:2145261"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "mirbase": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "miRBase"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>MI\\d{7})$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/mirbase/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00136"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Transcript"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "MI0003587",
-                            "MI0000252",
-                            "MI0000811",
-                            "MI0014201",
-                            "MI0003578",
-                            "MI0000293",
-                            "MI0006384",
-                            "MI0006361",
-                            "MI0000480",
-                            "MI0006419"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "mondo": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "MONDO"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^MONDO[:_](?<id>\\d{7})$"
-                      },
-                      "format": {
-                        "type": "string",
-                        "example": [
-                          "MONDO:%s",
-                          "MONDO_%s"
-                        ]
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://purl.obolibrary.org/obo/MONDO_"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc02563"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Disease"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "MONDO:0000115",
-                            "MONDO:0002345",
-                            "MONDO:0011571",
-                            "MONDO:0020035",
-                            "MONDO:0020920",
-                            "MONDO:0004627",
-                            "MONDO:0005480",
-                            "MONDO:0010852",
-                            "MONDO:0002053",
-                            "MONDO:0015758"
-                          ],
-                          [
-                            "MONDO_0000115",
-                            "MONDO_0002345",
-                            "MONDO_0011571",
-                            "MONDO_0020035",
-                            "MONDO_0020920",
-                            "MONDO_0004627",
-                            "MONDO_0005480",
-                            "MONDO_0010852",
-                            "MONDO_0002053",
-                            "MONDO_0015758"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "nando": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "NANDO"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^NANDO[:_](?<id>\\d{7})$"
-                      },
-                      "format": {
-                        "type": "string",
-                        "example": [
-                          "NANDO:%s",
-                          "NANDO_%s"
-                        ]
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://nanbyodata.jp/ontology/NANDO_"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc02557"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Disease"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "NANDO:1200461",
-                            "NANDO:1200466",
-                            "NANDO:1200851",
-                            "NANDO:1200061",
-                            "NANDO:1200315",
-                            "NANDO:1200365",
-                            "NANDO:1200922",
-                            "NANDO:1200705",
-                            "NANDO:2200074",
-                            "NANDO:1200030"
-                          ],
-                          [
-                            "NANDO_1200461",
-                            "NANDO_1200466",
-                            "NANDO_1200851",
-                            "NANDO_1200061",
-                            "NANDO_1200315",
-                            "NANDO_1200365",
-                            "NANDO_1200922",
-                            "NANDO_1200705",
-                            "NANDO_2200074",
-                            "NANDO_1200030"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "ncbigene": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "NCBI gene"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>\\d+)$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/ncbigene/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00073"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Gene"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "63962027",
-                            "1046",
-                            "63961921",
-                            "102606930",
-                            "100472895",
-                            "407025",
-                            "84148",
-                            "88",
-                            "31157",
-                            "100463227"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "ncbiprotein": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "NCBI protein"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?:(?:\\w+\\d+(?:\\.\\d+)?)|(?:NP_\\d+))$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/ncbiprotein/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00584"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Protein"
-                      }
-                    }
-                  },
-                  "oma_group": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "OMA group"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>[A-Z]+)$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/oma.grp/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc02221"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Ortholog"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "RVAAYKY",
-                            "LFVHAIL",
-                            "EMSPITC",
-                            "NQSHFFA",
-                            "AYTHYSY",
-                            "PRPKYDP",
-                            "WSRIHIV",
-                            "DFGGWKI",
-                            "FHVAHGE",
-                            "PYVYVTH"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "oma_protein": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "OMA protein"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>[A-Z]{3}[A-Z0-9]{2}[0-9]{5,6})$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/oma.protein/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc02221"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Protein"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "ACIB400217",
-                            "ACIB400465",
-                            "HUMAN00333",
-                            "HUMAN01170",
-                            "HUMAN00470",
-                            "HUMAN03367",
-                            "ACIB400486",
-                            "HUMAN01061",
-                            "HUMAN02190",
-                            "HUMAN02112"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "omim_gene": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "OMIM gene"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?:O?MIM:)?(?<id>\\d{6})$"
-                      },
-                      "format": {
-                        "type": "string",
-                        "example": [
-                          "%s",
-                          "OMIM:%s",
-                          "MIM:%s"
-                        ]
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/mim/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00154"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Gene"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "604810",
-                            "115460",
-                            "608706",
-                            "300181",
-                            "102575",
-                            "601280",
-                            "602832",
-                            "601604",
-                            "177075",
-                            "608977"
-                          ],
-                          [
-                            "OMIM:604810",
-                            "OMIM:115460",
-                            "OMIM:608706",
-                            "OMIM:300181",
-                            "OMIM:102575",
-                            "OMIM:601280",
-                            "OMIM:602832",
-                            "OMIM:601604",
-                            "OMIM:177075",
-                            "OMIM:608977"
-                          ],
-                          [
-                            "MIM:604810",
-                            "MIM:115460",
-                            "MIM:608706",
-                            "MIM:300181",
-                            "MIM:102575",
-                            "MIM:601280",
-                            "MIM:602832",
-                            "MIM:601604",
-                            "MIM:177075",
-                            "MIM:608977"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "omim_phenotype": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "OMIM phenotype"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?:O?MIM:)?(?<id>\\d{6})$"
-                      },
-                      "format": {
-                        "type": "string",
-                        "example": [
-                          "%s",
-                          "OMIM:%s",
-                          "MIM:%s"
-                        ]
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/mim/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00154"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Disease"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "207780",
-                            "236100",
-                            "237500",
-                            "300716",
-                            "125310",
-                            "165199",
-                            "617175",
-                            "137600",
-                            "600089",
-                            "601317"
-                          ],
-                          [
-                            "OMIM:207780",
-                            "OMIM:236100",
-                            "OMIM:237500",
-                            "OMIM:300716",
-                            "OMIM:125310",
-                            "OMIM:165199",
-                            "OMIM:617175",
-                            "OMIM:137600",
-                            "OMIM:600089",
-                            "OMIM:601317"
-                          ],
-                          [
-                            "MIM:207780",
-                            "MIM:236100",
-                            "MIM:237500",
-                            "MIM:300716",
-                            "MIM:125310",
-                            "MIM:165199",
-                            "MIM:617175",
-                            "MIM:137600",
-                            "MIM:600089",
-                            "MIM:601317"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "orphanet": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "Orphanet"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?:ORPHA|ORDO|Orphanet)[:_](?<id>[A-Z0-9]+)$"
-                      },
-                      "format": {
-                        "type": "string",
-                        "example": [
-                          "ORPHA:%s",
-                          "ORDO:%s",
-                          "Orphanet:%s",
-                          "Orphanet_%s"
-                        ]
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/orphanet.ordo/Orphanet_"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc01422"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Disease"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "ORPHA:101078",
-                            "ORPHA:596",
-                            "ORPHA:1934",
-                            "ORPHA:1047",
-                            "ORPHA:60025",
-                            "ORPHA:166090",
-                            "ORPHA:275745",
-                            "ORPHA:1171",
-                            "ORPHA:93277",
-                            "ORPHA:247598"
-                          ],
-                          [
-                            "ORDO:101078",
-                            "ORDO:596",
-                            "ORDO:1934",
-                            "ORDO:1047",
-                            "ORDO:60025",
-                            "ORDO:166090",
-                            "ORDO:275745",
-                            "ORDO:1171",
-                            "ORDO:93277",
-                            "ORDO:247598"
-                          ],
-                          [
-                            "Orphanet:101078",
-                            "Orphanet:596",
-                            "Orphanet:1934",
-                            "Orphanet:1047",
-                            "Orphanet:60025",
-                            "Orphanet:166090",
-                            "Orphanet:275745",
-                            "Orphanet:1171",
-                            "Orphanet:93277",
-                            "Orphanet:247598"
-                          ],
-                          [
-                            "Orphanet_101078",
-                            "Orphanet_596",
-                            "Orphanet_1934",
-                            "Orphanet_1047",
-                            "Orphanet_60025",
-                            "Orphanet_166090",
-                            "Orphanet_275745",
-                            "Orphanet_1171",
-                            "Orphanet_93277",
-                            "Orphanet_247598"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "pdb": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "PDB"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>[0-9][A-Za-z0-9]{3})$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://rdf.wwpdb.org/pdb/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00156"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Structure"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "3PFQ",
-                            "2OUY",
-                            "6EBX",
-                            "5GHP",
-                            "6ETH",
-                            "1Y28",
-                            "6FB2",
-                            "5JO3",
-                            "2JQZ",
-                            "5L5P"
-                          ],
-                          [
-                            "3pfq",
-                            "2ouy",
-                            "6ebx",
-                            "5ghp",
-                            "6eth",
-                            "1y28",
-                            "6fb2",
-                            "5jo3",
-                            "2jqz",
-                            "5l5p"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "pfam": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "Pfam"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>PF\\d{5})$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/pfam/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00163"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Domain"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "PF03719",
-                            "PF03726",
-                            "PF02809",
-                            "PF00105",
-                            "PF00250",
-                            "PF00412",
-                            "PF01412",
-                            "PF00459",
-                            "PF02532",
-                            "PF01226"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "pubchem_compound": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "PubChem compound"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?:CID)?(?<id>\\d+)$"
-                      },
-                      "format": {
-                        "type": "string",
-                        "example": [
-                          "%s",
-                          "CID%s"
-                        ]
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/pubchem.compound/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00641"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Compound"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "9548669",
-                            "160419",
-                            "9869929",
-                            "76333303",
-                            "9868491",
-                            "27854",
-                            "76329169",
-                            "3448",
-                            "296",
-                            "10371227"
-                          ],
-                          [
-                            "CID9548669",
-                            "CID160419",
-                            "CID9869929",
-                            "CID76333303",
-                            "CID9868491",
-                            "CID27854",
-                            "CID76329169",
-                            "CID3448",
-                            "CID296",
-                            "CID10371227"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "pubchem_substance": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "PubChem substance"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?:SID)?(?<id>\\d+)$"
-                      },
-                      "format": {
-                        "type": "string",
-                        "example": [
-                          "%s",
-                          "SID%s"
-                        ]
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/pubchem.substance/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00642"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Compound"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "15229855",
-                            "15277848",
-                            "15782795",
-                            "16076657",
-                            "16035895",
-                            "12012900",
-                            "15378994",
-                            "14850434",
-                            "14847540",
-                            "15271473"
-                          ],
-                          [
-                            "SID15229855",
-                            "SID15277848",
-                            "SID15782795",
-                            "SID16076657",
-                            "SID16035895",
-                            "SID12012900",
-                            "SID15378994",
-                            "SID14850434",
-                            "SID14847540",
-                            "SID15271473"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "pubmed": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "PubMed"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?:pmid:|PMID:)?(?<id>\\d+)$"
-                      },
-                      "format": {
-                        "type": "string",
-                        "example": [
-                          "%s",
-                          "pmid:%s",
-                          "PMID:%s"
-                        ]
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/pubmed/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00179"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Literature"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "19281226",
-                            "19879151",
-                            "20858243",
-                            "10773016",
-                            "16527252",
-                            "28499733",
-                            "10397770",
-                            "15149666",
-                            "23861362",
-                            "10577920"
-                          ],
-                          [
-                            "pmid:19281226",
-                            "pmid:19879151",
-                            "pmid:20858243",
-                            "pmid:10773016",
-                            "pmid:16527252",
-                            "pmid:28499733",
-                            "pmid:10397770",
-                            "pmid:15149666",
-                            "pmid:23861362",
-                            "pmid:10577920"
-                          ],
-                          [
-                            "PMID:19281226",
-                            "PMID:19879151",
-                            "PMID:20858243",
-                            "PMID:10773016",
-                            "PMID:16527252",
-                            "PMID:28499733",
-                            "PMID:10397770",
-                            "PMID:15149666",
-                            "PMID:23861362",
-                            "PMID:10577920"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "reactome_pathway": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "Reactome pathway"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>R-[A-Z]{3}-\\d+)(?:\\.\\d+)?$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/reactome/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00185"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Pathway"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "R-HSA-165159",
-                            "R-DRE-1630316",
-                            "R-SCE-9634635",
-                            "R-DRE-140834",
-                            "R-HSA-2142753",
-                            "R-BTA-383280",
-                            "R-MMU-5218900",
-                            "R-RNO-5654219",
-                            "R-MMU-8875791",
-                            "R-MMU-9648025"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "reactome_reaction": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "Reactome reaction"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>R-[A-Z]{3}-\\d+)(?:\\.\\d+)?$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/reactome/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00185"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Reaction"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "R-DRE-1482961",
-                            "R-DRE-6814409",
-                            "R-HSA-2395869",
-                            "R-HSA-1222722",
-                            "R-HSA-893583",
-                            "R-MMU-158484",
-                            "R-HSA-8875071",
-                            "R-HSA-372519",
-                            "R-HSA-6797627",
-                            "R-DRE-975814"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "refseq_genomic": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "RefSeq genomic"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>(?:AC_|N[CGTW]_|NZ_[A-Z]+)\\d+)(?:\\.\\d+)?$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/refseq/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00187"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Gene"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "NG_004671",
-                            "NG_011844",
-                            "NG_008481",
-                            "NG_007973",
-                            "NG_001091",
-                            "NG_008005",
-                            "NG_023230",
-                            "NG_046394",
-                            "NG_009617",
-                            "NG_016421",
-                            "NG_021472"
-                          ],
-                          [
-                            "NG_004671.3",
-                            "NG_011844.2",
-                            "NG_008481.4",
-                            "NG_007973.1",
-                            "NG_001091.7",
-                            "NG_008005.1",
-                            "NG_023230.1",
-                            "NG_046394.1",
-                            "NG_009617.1",
-                            "NG_016421.2",
-                            "NG_021472.2"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "refseq_protein": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "RefSeq protein"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>[ANXYWZ]P_\\d+)(?:\\.\\d+)?$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/refseq/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00187"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Protein"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "NP_001171968",
-                            "NP_001365494",
-                            "NP_000015",
-                            "XP_011522750",
-                            "XP_011516190",
-                            "XP_005265876",
-                            "WP_016919164",
-                            "WP_080513319",
-                            "YP_001687722",
-                            "YP_001966380"
-                          ],
-                          [
-                            "NP_001171968.1",
-                            "NP_001365494.1",
-                            "NP_000015.2",
-                            "XP_011522750.1",
-                            "XP_011516190.1",
-                            "XP_005265876.1",
-                            "WP_016919164.1",
-                            "WP_080513319.1",
-                            "YP_001687722.1",
-                            "YP_001966380.1"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "refseq_rna": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "RefSeq RNA"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>(?:NM|NR|XM|XR)_\\d+)(?:\\.\\d+)?$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/refseq/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00187"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Transcript"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "XR_001747779",
-                            "XM_017013006",
-                            "NM_001199636",
-                            "XM_011532496",
-                            "NM_001110",
-                            "NR_170162",
-                            "NM_020113",
-                            "NM_001031805",
-                            "NR_027673",
-                            "XR_934019"
-                          ],
-                          [
-                            "XR_001747779.1",
-                            "XM_017013006.1",
-                            "NM_001199636.2",
-                            "XM_011532496.1",
-                            "NM_001110.4",
-                            "NR_170162.1",
-                            "NM_020113.3",
-                            "NM_001031805.1",
-                            "NR_027673.1",
-                            "XR_934019.3"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "rgd": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "RGD"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?:(?:RGD|rgd):)?(?<id>\\d{4,})$"
-                      },
-                      "format": {
-                        "type": "string",
-                        "example": [
-                          "%s",
-                          "RGD:%s",
-                          "rgd:%s"
-                        ]
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/rgd/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00188"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Gene"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "1308312",
-                            "1311120",
-                            "1309724",
-                            "1565514",
-                            "7683241",
-                            "1307957",
-                            "71036",
-                            "1307876",
-                            "1308965",
-                            "1305482"
-                          ],
-                          [
-                            "RGD:1308312",
-                            "RGD:1311120",
-                            "RGD:1309724",
-                            "RGD:1565514",
-                            "RGD:7683241",
-                            "RGD:1307957",
-                            "RGD:71036",
-                            "RGD:1307876",
-                            "RGD:1308965",
-                            "RGD:1305482"
-                          ],
-                          [
-                            "rgd:1308312",
-                            "rgd:1311120",
-                            "rgd:1309724",
-                            "rgd:1565514",
-                            "rgd:7683241",
-                            "rgd:1307957",
-                            "rgd:71036",
-                            "rgd:1307876",
-                            "rgd:1308965",
-                            "rgd:1305482"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "rhea": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "Rhea"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>\\d{5})$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/rhea/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc02083"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Reaction"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "10253",
-                            "10818",
-                            "13517",
-                            "11136",
-                            "13729",
-                            "10240",
-                            "11728",
-                            "16870",
-                            "10732",
-                            "11278"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "sra_accession": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "SRA accession"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>[SED]RA\\d+)$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/insdc.sra/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00687"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Submission"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "DRA000741",
-                            "DRA000768",
-                            "DRA001014",
-                            "DRA000833",
-                            "SRA000144",
-                            "SRA000605",
-                            "SRA008879",
-                            "ERA007227",
-                            "ERA011638",
-                            "ERA013580"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "sra_analysis": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "SRA analysis"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>[SED]RZ\\d+)$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/insdc.sra/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00687"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Analysis"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "DRZ000249",
-                            "DRZ000087",
-                            "DRZ003045",
-                            "DRZ000829",
-                            "SRZ168127",
-                            "SRZ008405",
-                            "SRZ010259",
-                            "SRZ011419",
-                            "SRZ006662",
-                            "SRZ010567"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "sra_experiment": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "SRA experiment"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>[SED]RX\\d+)$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/insdc.sra/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00687"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Experiment"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "DRX000585",
-                            "DRX000114",
-                            "DRX000613",
-                            "DRX000681",
-                            "SRX000921",
-                            "SRX000254",
-                            "SRX000626",
-                            "ERX149204",
-                            "ERX001260",
-                            "ERX000427"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "sra_project": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "SRA project"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>[SED]RP\\d+)$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/insdc.sra/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00687"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Project"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "DRP000994",
-                            "DRP000877",
-                            "DRP000649",
-                            "DRP000147",
-                            "SRP266466",
-                            "SRP297268",
-                            "SRP000065",
-                            "ERP001266",
-                            "ERP007720",
-                            "ERP104141"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "sra_run": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "SRA run"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>[SED]RR\\d+)$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/insdc.sra/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00687"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "SequenceRun"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "DRR000834",
-                            "DRR000683",
-                            "DRR000264",
-                            "DRR000453",
-                            "SRR029947",
-                            "SRR000290",
-                            "SRR004854",
-                            "ERR499402",
-                            "ERR004130",
-                            "ERR000715"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "sra_sample": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "SRA sample"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>[SED]RS\\d+)$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/insdc.sra/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00687"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Sample"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "DRS001431",
-                            "DRS001371",
-                            "DRS000894",
-                            "DRS000386",
-                            "SRS2618009",
-                            "SRS7846025",
-                            "SRS000159",
-                            "ERS452503",
-                            "ERS000126",
-                            "ERS010423"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "taxonomy": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "Taxonomy"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>\\d+)$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/taxonomy/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00700"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Taxonomy"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "1171376",
-                            "484906",
-                            "1214242",
-                            "1124991",
-                            "1037911",
-                            "1266844",
-                            "243277",
-                            "696747",
-                            "263820",
-                            "713604"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "togovar": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "TogoVar variant"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>tgv\\d+)$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://togovar.biosciencedbc.jp/variation/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc02359"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Variant"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "tgv100005930",
-                            "tgv100000890",
-                            "tgv16331",
-                            "tgv10000341",
-                            "tgv21330879",
-                            "tgv15847",
-                            "tgv1354996",
-                            "tgv100002132",
-                            "tgv16568524",
-                            "tgv62035164"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "uniprot": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "UniProt"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?:(?<id1>[A-NR-Z][0-9](?:[A-Z][A-Z0-9][A-Z0-9][0-9]){1,2}(?:-\\d+)?)|(?<id2>[OPQ][0-9][A-Z0-9][A-Z0-9][A-Z0-9][0-9](?:-\\d+)?)(?:\\.\\d+)?)$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://purl.uniprot.org/uniprot/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00221"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Protein"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "A0A174V9D2",
-                            "A0A1V4U2Y9",
-                            "Q7NXD4",
-                            "P0AAM3",
-                            "O43423",
-                            "D4IJI4",
-                            "Q66SS1",
-                            "B5IDU9",
-                            "D3TBR4",
-                            "D4ILS5"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "uniprot_mnemonic": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "UniProt mnemonic"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>[A-Z0-9]+_[A-Z0-9]{0,5})$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://purl.uniprot.org/uniprot/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc00221"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Protein"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "2ABA_ORYSJ",
-                            "33K_ADES1",
-                            "1003L_ASFK5",
-                            "1A1D_VARPS",
-                            "1B02_GORGO",
-                            "1003L_ASFP4",
-                            "1433B_MACFA",
-                            "1107L_ASFWA",
-                            "3BHS1_MOUSE",
-                            "14331_SCHMA"
-                          ]
-                        ]
-                      }
-                    }
-                  },
-                  "wikipathways": {
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "example": "WikiPathways"
-                      },
-                      "regex": {
-                        "type": "string",
-                        "example": "^(?<id>WP\\d{1,5})(?:\\_r\\d+)?$"
-                      },
-                      "prefix": {
-                        "type": "string",
-                        "example": "http://identifiers.org/wikipathways/"
-                      },
-                      "catalog": {
-                        "type": "string",
-                        "example": "nbdc02116"
-                      },
-                      "category": {
-                        "type": "string",
-                        "example": "Pathway"
-                      },
-                      "examples": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "example": [
-                          [
-                            "WP1531",
-                            "WP4312",
-                            "WP4877",
-                            "WP5020",
-                            "WP4400",
-                            "WP4474",
-                            "WP4183",
-                            "WP3650",
-                            "WP4545",
-                            "WP4462"
-                          ],
-                          [
-                            "WP1531_r107120",
-                            "WP4312_r104287",
-                            "WP4877_r116595",
-                            "WP5020_r114721",
-                            "WP4400_r108112",
-                            "WP4474_r102094",
-                            "WP4183_r106890",
-                            "WP3650_r110699",
-                            "WP4545_r116235",
-                            "WP4462_r102079"
-                          ]
-                        ]
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "Bad request"
-            }
-          }
-        }
-      },
-      "/config/dataset/{dataset}": {
-        "get": {
-          "tags": [
-            "config"
-          ],
-          "summary": "Get selected dataset config",
-          "operationId": "getDataset",
-          "parameters": [
-            {
-              "name": "dataset",
-              "in": "path",
-              "type": "string",
-              "description": "A key from https://github.com/dbcls/togoid-config/blob/main/config/dataset.yaml",
-              "required": true
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "successful operation",
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "label": {
-                    "type": "string",
-                    "example": "UniProt"
-                  },
-                  "regex": {
-                    "type": "string",
-                    "example": "^(?:(?<id1>[A-NR-Z][0-9](?:[A-Z][A-Z0-9][A-Z0-9][0-9]){1,2}(?:-\\d+)?)|(?<id2>[OPQ][0-9][A-Z0-9][A-Z0-9][A-Z0-9][0-9](?:-\\d+)?)(?:\\.\\d+)?)$"
-                  },
-                  "prefix": {
-                    "type": "string",
-                    "example": "http://purl.uniprot.org/uniprot/"
-                  },
-                  "catalog": {
-                    "type": "string",
-                    "example": "nbdc00221"
-                  },
-                  "category": {
-                    "type": "string",
-                    "example": "Protein"
-                  },
-                  "examples": {
-                    "type": "array",
-                    "items": {
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ids": {
                       "type": "string",
                       "example": [
-                        "A0A174V9D2",
-                        "A0A1V4U2Y9",
-                        "Q7NXD4",
-                        "P0AAM3",
-                        "O43423",
-                        "D4IJI4",
-                        "Q66SS1",
-                        "B5IDU9",
-                        "D3TBR4",
-                        "D4ILS5"
+                        "26199",
+                        "38937",
+                        "14027",
+                        "21498",
+                        "18185",
+                        "1314",
+                        "25960",
+                        "2206",
+                        "22224",
+                        "19741"
+                      ]
+                    },
+                    "route": {
+                      "type": "string",
+                      "example": ["hgnc", "ensembl_gene"]
+                    },
+                    "result": {
+                      "type": "string",
+                      "example": [
+                        "ENSG00000100364",
+                        "ENSG00000154719",
+                        "ENSG00000116285",
+                        "ENSG00000179454",
+                        "ENSG00000085978",
+                        "ENSG00000081052",
+                        "ENSG00000006459",
+                        "ENSG00000198088",
+                        "ENSG00000134152",
+                        "ENSG00000284140"
                       ]
                     }
                   }
                 }
               }
-            },
-            "400": {
-              "description": "Bad request"
             }
+          },
+          "400": {
+            "description": "Bad request"
           }
         }
-      },
-      "/config/relation": {
-        "get": {
-          "tags": [
-            "config"
-          ],
-          "summary": "Get all database relation",
-          "operationId": "getAllRelation",
-          "responses": {
-            "200": {
-              "description": "successful operation",
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "affy_probeset-ncbigene": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "detects"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is target of"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "chebi-inchi_key": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is represented as"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "represents"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "chembl_compound-chebi": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "chembl_compound-chembl_target": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "interacts with"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "interacts with"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "chembl_compound-drugbank": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "chembl_compound-hmdb": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "chembl_compound-inchi_key": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is represented as"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "represents"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "chembl_compound-mesh": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has related disease"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is related with"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "chembl_compound-pubchem_compound": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "chembl_compound-pubchem_substance": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "chembl_compound-pubmed": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has reference"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is reference of"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "chembl_target-ensembl_gene": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is product of gene"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has gene product"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "chembl_target-go": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has GO cellular component"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is GO cellular component of"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "chembl_target-interpro": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has protein domain"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is in protein"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "chembl_target-pdb": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has 3D structure"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is 3D structure of"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "chembl_target-pfam": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has protein domain"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is in protein"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "chembl_target-reactome_pathway": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "participates in pathway"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has participant molecule"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "chembl_target-uniprot": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "clinvar-medgen": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has related disease"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is related with"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "doid-mesh": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "doid-omim_phenotype": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "ensembl_gene-affy_probeset": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is target of"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "detects"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "ensembl_gene-ensembl_protein": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has gene product"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is product of gene"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "ensembl_gene-ensembl_transcript": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is transcribed to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is transcribed from"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "ensembl_gene-hgnc": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "ensembl_gene-ncbigene": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "ensembl_gene-uniprot": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has gene product"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is product of gene"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "ensembl_protein-ensembl_transcript": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is tranlated from"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is translated to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "ensembl_transcript-affy_probeset": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is target of"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "detects"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "ensembl_transcript-go": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has GO annotation"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is GO annotation of"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "ensembl_transcript-hgnc": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is transcribed from"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is transcribed to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "ensembl_transcript-refseq_rna": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "glytoucan-doid": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has related disease"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is related with"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "glytoucan-uniprot": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is attached to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is modified with"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "hgnc-ccds": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "hgnc-ec": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has EC number"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is EC number of"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "hgnc-ensembl_gene": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "hgnc-hgnc_symbol": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has synonym"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is synonym of"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "hgnc-insdc": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "hgnc-lrg": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "hgnc-mgi": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is orthologous to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is orthologous to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "hgnc-mirbase": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is transcribed to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is transcribed from"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "hgnc-ncbigene": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "hgnc-omim_gene": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "hgnc-pubmed": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has reference"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is reference of"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "hgnc-refseq_rna": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is transcribed to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is transcribed from"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "hgnc-rgd": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is orthologous to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is orthologous to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "hgnc-uniprot": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has gene product"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is product of gene"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "homologene-ncbigene": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has orthologous group member"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is member of orthologous group"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "interpro-go": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has GO annotation"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is GO annotation of"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "interpro-pdb": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is in structure"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has protein domain"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "interpro-pfam": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "interpro-pubmed": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has reference"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is reference of"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "interpro-reactome_pathway": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "participates in pathway"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has protein domain in pathway"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "interpro-uniprot": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is in protein"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has protein domain"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "mbgd_gene-uniprot": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has gene product"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is product of gene"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "mbgd_organism-taxonomy": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "medgen-hp": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "medgen-mesh": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "medgen-mondo": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "medgen-ncbigene": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is related with"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has related disease"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "medgen-omim_phenotype": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "medgen-orphanet": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "mondo-doid": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "mondo-hp": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "mondo-meddra": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "mondo-mesh": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "mondo-omim_phenotype": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "mondo-orphanet": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "nando-mondo": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "ncbigene-ensembl_gene": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "ncbigene-ensembl_protein": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has gene product"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is product of gene"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "ncbigene-ensembl_transcript": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is transcribed to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is transcribed from"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "ncbigene-go": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has GO annotation"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is GO annotation of"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "ncbigene-hgnc": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "ncbigene-mirbase": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is transcribed to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is transcribed from"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "ncbigene-omim_gene": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "ncbigene-refseq_genomic": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "ncbigene-refseq_protein": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has gene product"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is product of gene"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "ncbigene-refseq_rna": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is transcribed to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is transcribed from"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "ncbigene-taxonomy": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is gene of organism"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has gene"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "oma_protein-ensembl_gene": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is product of gene"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has gene product"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "oma_protein-ensembl_transcript": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is tranlated from"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is translated to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "oma_protein-uniprot": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "orphanet-meddra": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "orphanet-mesh": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "orphanet-omim_phenotype": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "pdb-go": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has GO annotation"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is GO annotation of"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "pdb-interpro": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has protein domain"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is in protein"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "pdb-pfam": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has protein domain"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is in protein"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "pdb-uniprot": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is 3D structure of"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has 3D structure"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "pubchem_compound-chebi": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "pubchem_compound-chembl_compound": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "pubchem_compound-drugbank": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "pubchem_compound-glytoucan": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "pubchem_compound-inchi_key": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is represented as"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "represents"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "reactome_pathway-go": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has GO biological process"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is GO biological process of"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "reactome_pathway-reactome_reaction": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has participant reaction"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "participates in pathway"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "reactome_reaction-chebi": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has participant molecule"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "participates in pathway"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "reactome_reaction-go": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has GO biological process"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is GO biological process of"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "reactome_reaction-uniprot": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has participant molecule"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "participates in pathway"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "refseq_protein-uniprot": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "refseq_rna-dbsnp": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has variant"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is located in"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "refseq_rna-hgnc": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is transcribed from"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is transcribed to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "refseq_rna-ncbigene": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is transcribed from"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is transcribed to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "refseq_rna-omim_gene": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is transcribed from"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is transcribed to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "refseq_rna-pubmed": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has reference"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is reference of"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "refseq_rna-refseq_protein": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is translated to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is tranlated from"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "refseq_rna-taxonomy": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is gene of organism"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has gene"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "rhea-chebi": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has participant molecule"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "participates in pathway"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "rhea-ec": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "rhea-reactome_reaction": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is nearly equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "sra_accession-bioproject": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "includes project"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "belongs to submission"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "sra_accession-biosample": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "includes sample"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "belongs to submission"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "sra_accession-sra_analysis": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "includes analysis"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "belongs to submission"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "sra_accession-sra_experiment": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "includes experiment"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "belongs to submission"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "sra_accession-sra_project": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "includes project"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "belongs to submission"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "sra_accession-sra_run": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "includes sequence run"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "belongs to submission"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "sra_accession-sra_sample": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "includes sample"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "belongs to submission"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "sra_experiment-bioproject": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "belongs to project"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "performs experiment"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "sra_experiment-biosample": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "captures sample"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is captured to perform experiment"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "sra_experiment-sra_project": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "belongs to project"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "performs experiment"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "sra_experiment-sra_sample": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "captures sample"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is captured to perform experiment"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "sra_project-bioproject": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "sra_run-bioproject": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "belongs to project"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "produces sequence run"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "sra_run-biosample": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is produced from sample"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is captured to produce sequence run"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "sra_run-sra_experiment": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is produced in experiment"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "produces sequence run"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "sra_run-sra_project": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "belongs to project"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "produces sequence run"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "sra_run-sra_sample": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is produced from sample"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is captured to produce sequence run"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "sra_sample-biosample": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "togovar-clinvar": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has clinical significance"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is clinical significance of"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "togovar-dbsnp": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has corresponding variant"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has corresponding variant"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "togovar-ensembl_gene": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is located in"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has variant"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "togovar-ensembl_transcript": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is located in"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has variant"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "togovar-hgnc": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is located in"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has variant"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "togovar-ncbigene": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is located in"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has variant"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "togovar-pubmed": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has reference"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is reference of"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "togovar-refseq_rna": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is located in"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has variant"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "uniprot-chembl_target": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "uniprot-dbsnp": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has variant"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is located in"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "uniprot-ec": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has EC number"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is EC number of"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "uniprot-ensembl_gene": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is product of gene"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has gene product"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "uniprot-ensembl_protein": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "uniprot-ensembl_transcript": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is tranlated from"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is translated to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "uniprot-go": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has GO annotation"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is GO annotation of"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "uniprot-hgnc": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is product of gene"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has gene product"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "uniprot-insdc": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is product of gene"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has gene product"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "uniprot-intact": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "participates in pathway"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has participant molecule"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "uniprot-ncbigene": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is product of gene"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has gene product"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "uniprot-oma_group": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is member of orthologous group"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has orthologous group member"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "uniprot-omim_gene": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is product of gene"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has gene product"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "uniprot-omim_phenotype": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has related disease"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is related with"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "uniprot-orphanet": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has related disease"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is related with"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "uniprot-pdb": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has 3D structure"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is 3D structure of"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "uniprot-pfam": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has protein domain"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is in protein"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "uniprot-reactome_pathway": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "participates in pathway"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has participant molecule"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "uniprot-refseq_protein": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is equivalent to"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is equivalent to"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "uniprot-uniprot_mnemonic": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has synonym"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is synonym of"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "wikipathways-chebi": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has participant molecule"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "participates in pathway"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "wikipathways-doid": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has related disease"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "is related with"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "wikipathways-uniprot": {
-                    "properties": {
-                      "link": {
-                        "type": "object",
-                        "properties": {
-                          "forward": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "has participant molecule"
-                              }
-                            }
-                          },
-                          "reverse": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string",
-                                "example": "participates in pathway"
+      }
+    },
+    "/count/{source}-{target}": {
+      "get": {
+        "tags": ["count"],
+        "summary": "Count IDs",
+        "operationId": "countId",
+        "parameters": [
+          {
+            "name": "source",
+            "in": "path",
+            "description": "A key from https://github.com/dbcls/togoid-config/blob/main/config/dataset.yaml",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "target",
+            "in": "path",
+            "description": "A key from https://github.com/dbcls/togoid-config/blob/main/config/dataset.yaml",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "ids",
+            "in": "query",
+            "description": "List IDs separated by commas",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "source": {
+                      "type": "string",
+                      "example": 2
+                    },
+                    "target": {
+                      "type": "string",
+                      "example": 2
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          }
+        }
+      }
+    },
+    "/config/dataset": {
+      "get": {
+        "tags": ["config"],
+        "summary": "Get all dataset config",
+        "operationId": "getAllDataset",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "affy_probeset": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "Affymetrix probeset"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>\\d{3,}(?:_[a-z])?_at)$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/affy.probeset/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "FIXME"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Probe"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "1553582_a_at",
+                              "211531_x_at",
+                              "202573_at",
+                              "201640_x_at",
+                              "205117_at",
+                              "201017_at",
+                              "205099_s_at",
+                              "200614_at",
+                              "201895_at",
+                              "202666_s_at"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "bioproject": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "BioProject"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>PRJ[DEN][A-Z]\\d+)$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/bioproject/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00476"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Project"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "PRJDB575",
+                              "PRJDB1880",
+                              "PRJDB478",
+                              "PRJDA45949",
+                              "PRJEB6285",
+                              "PRJEA28961",
+                              "PRJEB2222",
+                              "PRJNA30641",
+                              "PRJNA68235",
+                              "PRJNA42549"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "biosample": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "BioSample"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>SAM[NED]\\w?\\d+)$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/biosample/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc01983"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Sample"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "SAMD00003683",
+                              "SAMD00006315",
+                              "SAMD00003741",
+                              "SAMD00011226",
+                              "SAMN13091859",
+                              "SAMN05877962",
+                              "SAMN05877838",
+                              "SAMEA104232303",
+                              "SAMEA4760552",
+                              "SAMEA1572228"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "ccds": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "Consensus CDS"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>CCDS\\d+)(?:\\.\\d+)?$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/ccds/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00023"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Gene"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "CCDS1471",
+                              "CCDS10913",
+                              "CCDS14790",
+                              "CCDS35175",
+                              "CCDS2395",
+                              "CCDS58412",
+                              "CCDS55555",
+                              "CCDS34401",
+                              "CCDS41889",
+                              "CCDS9052"
+                            ],
+                            [
+                              "CCDS1471.1",
+                              "CCDS10913.1",
+                              "CCDS14790.1",
+                              "CCDS35175.2",
+                              "CCDS2395.1",
+                              "CCDS58412.1",
+                              "CCDS55555.1",
+                              "CCDS34401.2",
+                              "CCDS41889.1",
+                              "CCDS9052.1"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "chebi": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "ChEBI compound"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?:CHEBI[:_])?(?<id>\\d+)$"
+                        },
+                        "format": {
+                          "type": "string",
+                          "example": ["%s", "CHEBI:%s", "CHEBI_%"]
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://purl.obolibrary.org/obo/CHEBI_"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00027"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Compound"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "84824",
+                              "40167",
+                              "32807",
+                              "87666",
+                              "57524",
+                              "64860",
+                              "94440",
+                              "18005",
+                              "4806",
+                              "50158"
+                            ],
+                            [
+                              "CHEBI:84824",
+                              "CHEBI:40167",
+                              "CHEBI:32807",
+                              "CHEBI:87666",
+                              "CHEBI:57524",
+                              "CHEBI:64860",
+                              "CHEBI:94440",
+                              "CHEBI:18005",
+                              "CHEBI:4806",
+                              "CHEBI:50158"
+                            ],
+                            [
+                              "CHEBI_84824",
+                              "CHEBI_40167",
+                              "CHEBI_32807",
+                              "CHEBI_87666",
+                              "CHEBI_57524",
+                              "CHEBI_64860",
+                              "CHEBI_94440",
+                              "CHEBI_18005",
+                              "CHEBI_4806",
+                              "CHEBI_50158"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "chembl_compound": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "ChEMBL compound"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>CHEMBL\\d+)$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/chembl.compound/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc02555"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Compound"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "CHEMBL121649",
+                              "CHEMBL190334",
+                              "CHEMBL3103282",
+                              "CHEMBL69329",
+                              "CHEMBL2105131",
+                              "CHEMBL2177390",
+                              "CHEMBL3091820",
+                              "CHEMBL1200335",
+                              "CHEMBL3094412",
+                              "CHEMBL67367"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "chembl_target": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "ChEMBL target"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>CHEMBL\\d+)$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/chembl.target/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc02555"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Protein"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "CHEMBL2788",
+                              "CHEMBL3091264",
+                              "CHEMBL3831324",
+                              "CHEMBL5524",
+                              "CHEMBL5597",
+                              "CHEMBL3983",
+                              "CHEMBL4187",
+                              "CHEMBL3391681",
+                              "CHEMBL5135",
+                              "CHEMBL1255130"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "civic_gene": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "CIVIC gene"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>\\d+)$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://civic.genome.wustl.edu/links/genes/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc02558"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Gene"
+                        }
+                      }
+                    },
+                    "clinvar": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "ClinVar variant"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(VCV0*)?(?<id>(\\d{1,9}))$"
+                        },
+                        "format": {
+                          "type": "string",
+                          "example": ["%s", "VCV%09d"]
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/clinvar/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc01514"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Variant"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "658761",
+                              "619209",
+                              "745342",
+                              "11955",
+                              "731668",
+                              "724289",
+                              "725734",
+                              "743127",
+                              "789913",
+                              "5302"
+                            ],
+                            [
+                              "VCV000658761",
+                              "VCV000619209",
+                              "VCV000745342",
+                              "VCV000011955",
+                              "VCV000731668",
+                              "VCV000724289",
+                              "VCV000725734",
+                              "VCV000743127",
+                              "VCV000789913",
+                              "VCV000005302"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "dbsnp": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "dbSNP"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>rs\\d+)$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/dbsnp/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00206"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Variant"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "rs746303788",
+                              "rs1407020249",
+                              "rs374003162",
+                              "rs4647297",
+                              "rs549539526",
+                              "rs1387864740",
+                              "rs1177577242",
+                              "rs769848663",
+                              "rs16961655",
+                              "rs79135400"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "dgidb": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "DGIdb"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "FIXME"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc02562"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Interaction"
+                        }
+                      }
+                    },
+                    "doid": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "Disease ontology"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^DO(?:ID)?[:_](?<id>\\d+)$"
+                        },
+                        "format": {
+                          "type": "string",
+                          "example": ["DO:%s", "DOID:%s", "DOID_%s"]
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://purl.obolibrary.org/obo/DOID_"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00261"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Disease"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "DO:9036",
+                              "DO:3159",
+                              "DO:10964",
+                              "DO:12698",
+                              "DO:0060459",
+                              "DO:11840",
+                              "DO:11339",
+                              "DO:914",
+                              "DO:9945",
+                              "DO:1407"
+                            ],
+                            [
+                              "DOID:9036",
+                              "DOID:3159",
+                              "DOID:10964",
+                              "DOID:12698",
+                              "DOID:0060459",
+                              "DOID:11840",
+                              "DOID:11339",
+                              "DOID:914",
+                              "DOID:9945",
+                              "DOID:1407"
+                            ],
+                            [
+                              "DOID_9036",
+                              "DOID_3159",
+                              "DOID_10964",
+                              "DOID_12698",
+                              "DOID_0060459",
+                              "DOID_11840",
+                              "DOID_11339",
+                              "DOID_914",
+                              "DOID_9945",
+                              "DOID_1407"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "drugbank": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "DrugBank"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>DB\\d{5})$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/drugbank/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc01071"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Compound"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "DB15589",
+                              "DB13471",
+                              "DB05830",
+                              "DB07423",
+                              "DB07074",
+                              "DB08912",
+                              "DB02908",
+                              "DB05088",
+                              "DB05229",
+                              "DB08910"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "ec": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "Enzyme nomenclature"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?:EC:)?(?<id>\\d+\\.(?:(?:-\\.-\\.-)|\\d+\\.(?:(?:-\\.-)|\\d+\\.(?:-|n?\\d+))))$"
+                        },
+                        "format": {
+                          "type": "string",
+                          "example": ["%s", "EC:%s"]
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/ec-code/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc01883"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Function"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "1.6.3.1",
+                              "2.4.1.353",
+                              "1.1.1.288",
+                              "1.5.1.2",
+                              "3.1.1.71",
+                              "1.3.1.31",
+                              "3.5.1.29",
+                              "1.16.1.1",
+                              "3.1.3.48",
+                              "2.3.1.138"
+                            ],
+                            [
+                              "EC:1.6.3.1",
+                              "EC:2.4.1.353",
+                              "EC:1.1.1.288",
+                              "EC:1.5.1.2",
+                              "EC:3.1.1.71",
+                              "EC:1.3.1.31",
+                              "EC:3.5.1.29",
+                              "EC:1.16.1.1",
+                              "EC:3.1.3.48",
+                              "EC:2.3.1.138"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "ena": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "ENA"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?:ena\\.embl:)?(?<id>[A-Z]+[0-9]+)(?:\\.\\d+)?$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/ena.embl/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00432"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Gene"
+                        }
+                      }
+                    },
+                    "ensembl_gene": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "Ensembl gene"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?:(?:(?<id1>ENS[A-Z]*G\\d{11})(?:\\.\\d+)?)|(?<id2>FBgn\\d{7})|(?:(?<id3>MGP_[A-Za-z0-9]+_G\\d{7})(?:\\.\\d+)?)|(?<id4>LRG_\\d+)|(?<id5>WBGene\\d{8})|(?<id6>Y[A-Z]{2}\\d{3}[A-Z](?:-[A-Z])?)|(?<id7>Q\\d{4})|(?<id8>[A-Z]{3}\\d{1,3}(?:-\\d)?)|(?<id9>snR\\d+-?[A-Za-z]?)|(?<id10>t[A-Z]\\([ACGUX]{3}\\)[A-Z]\\d?))$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/ensembl/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00054"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Gene"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "ENSG00000186283",
+                              "ENSAMEG00000018238",
+                              "ENSG00000167916",
+                              "ENSG00000213417",
+                              "ENSG00000133328",
+                              "ENSG00000274404",
+                              "ENSG00000184363",
+                              "FBgn0021742",
+                              "FBgn0030057",
+                              "FBgn0265139"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "ensembl_protein": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "Ensembl protein"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?:(?:(?<id1>ENS[A-Z]*P\\d{11})(?:\\.\\d+)?)|(?<id2>FBpp\\d{7})|(?:(?<id3>MGP_[A-Za-z0-9]+_P\\d{7})(?:\\.\\d+)?)|(?<id4>LRG_\\d+p\\d+(?:-\\d)?)|(?<id5>(?:[A-Za-z0-9][A-Za-z0-9_]+)\\.t?\\d+[a-z]?(?:\\.\\d+)?)|(?<id6>Y[A-Z]{2}\\d{3}[A-Z](?:-[A-Z])?)|(?<id7>Q\\d{4}))$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/ensembl/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00054"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Protein"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "ENSP00000365411",
+                              "ENSP00000420674",
+                              "ENSAZOP00000020796",
+                              "FBpp0070277",
+                              "FBpp0070535",
+                              "ENSAZOP00000019433",
+                              "ENSP00000372042",
+                              "ENSAZOP00000017910",
+                              "ENSP00000370977",
+                              "ENSP00000481894"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "ensembl_transcript": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "Ensembl transcript"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?:(?:(?<id1>ENS[A-Z]*T\\d{11})(?:\\.\\d+)?)|(?<id2>FBtr\\d{7})|(?:(?<id3>MGP_[A-Za-z0-9]+_T\\d{7})(?:\\.\\d+)?)|(?<id4>LRG_\\d+t\\d+(?:-\\d)?)|(?<id5>(?:[A-Za-z0-9][A-Za-z0-9_]+)\\.t?\\d+[a-z]?(?:\\.\\d+)?)|(?<id6>Y[A-Z]{2}\\d{3}[A-Z](?:-[A-Z])?(?:_[a-z]{1,3}RNA)?)|(?<id7>Q\\d{4}_[a-z]{1,3}RNA)|(?<id8>[A-Z]{3}\\d{1,3}(?:-\\d)?_[a-z]{1,3}RNA)|(?<id9>snR\\d+-?[A-Za-z]?_sno?RNA)|(?<id10>t[A-Z]\\([ACGUX]{3}\\)[A-Z]\\d?_tRNA))$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/ensembl/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00054"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Transcript"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "ENST00000638000",
+                              "ENST00000307864",
+                              "ENSTRUT00000006732",
+                              "ENSAMET00000021072",
+                              "ENSAZOT00000021040",
+                              "ENST00000622541",
+                              "ENST00000462612",
+                              "ENSBTAT00000072441",
+                              "ENSAZOT00000005048",
+                              "ENST00000475822"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "glytoucan": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "GlyTouCan"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>G[0-9]{5}[A-Z]{2})$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/glytoucan/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc01535"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Glycan"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "G88006IV",
+                              "G53085MI",
+                              "G17896UT",
+                              "G50341PG",
+                              "G19379ID",
+                              "G08110WX",
+                              "G70101JE",
+                              "G45504EY",
+                              "G81263BG",
+                              "G02815KT"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "go": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "Gene ontology"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^GO[:_](?<id>\\d{7})$"
+                        },
+                        "format": {
+                          "type": "string",
+                          "example": ["GO:%s", "GO_%s"]
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://purl.obolibrary.org/obo/GO_"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00074"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Function"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "GO:0005643",
+                              "GO:0097110",
+                              "GO:0097225",
+                              "GO:0052855",
+                              "GO:2000012",
+                              "GO:0042921",
+                              "GO:0019774",
+                              "GO:0085018",
+                              "GO:0009508",
+                              "GO:0046470"
+                            ],
+                            [
+                              "GO_0005643",
+                              "GO_0097110",
+                              "GO_0097225",
+                              "GO_0052855",
+                              "GO_2000012",
+                              "GO_0042921",
+                              "GO_0019774",
+                              "GO_0085018",
+                              "GO_0009508",
+                              "GO_0046470"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "hgnc": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "HGNC"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?:(?:HGNC|hgnc):)?(?<id>\\d{1,5})$"
+                        },
+                        "format": {
+                          "type": "string",
+                          "example": ["%s", "HGNC:%s", "hgnc:%s"]
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/hgnc/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc01774"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Gene"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "26199",
+                              "38937",
+                              "14027",
+                              "21498",
+                              "18185",
+                              "1314",
+                              "25960",
+                              "2206",
+                              "22224",
+                              "19741"
+                            ],
+                            [
+                              "HGNC:26199",
+                              "HGNC:38937",
+                              "HGNC:14027",
+                              "HGNC:21498",
+                              "HGNC:18185",
+                              "HGNC:1314",
+                              "HGNC:25960",
+                              "HGNC:2206",
+                              "HGNC:22224",
+                              "HGNC:19741"
+                            ],
+                            [
+                              "hgnc:26199",
+                              "hgnc:38937",
+                              "hgnc:14027",
+                              "hgnc:21498",
+                              "hgnc:18185",
+                              "hgnc:1314",
+                              "hgnc:25960",
+                              "hgnc:2206",
+                              "hgnc:22224",
+                              "hgnc:19741"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "hgnc_symbol": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "HGNC gene symbol"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>[A-Za-z0-9_\\-]+\\@?)$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/hgnc.symbol/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc01774"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Gene"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "MBNL2",
+                              "RGS20",
+                              "LINC02011",
+                              "IGHV1-14",
+                              "SH3RF2",
+                              "SPATA13",
+                              "HNRNPCP10",
+                              "LINC00334",
+                              "TMEM241",
+                              "RN7SL753P"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "hmdb": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "HMDB"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?:hmdb:)?(?<id>HMDB\\d+)$"
+                        },
+                        "format": {
+                          "type": "string",
+                          "example": ["%s", "hmdb:%s"]
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/hmdb/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00909"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Compound"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "HMDB0029433",
+                              "HMDB0015609",
+                              "HMDB0000042",
+                              "HMDB0002360",
+                              "HMDB0003345",
+                              "HMDB0003550",
+                              "HMDB0036769",
+                              "HMDB0000935",
+                              "HMDB0002755",
+                              "HMDB0004369"
+                            ],
+                            [
+                              "hmdb:HMDB0029433",
+                              "hmdb:HMDB0015609",
+                              "hmdb:HMDB0000042",
+                              "hmdb:HMDB0002360",
+                              "hmdb:HMDB0003345",
+                              "hmdb:HMDB0003550",
+                              "hmdb:HMDB0036769",
+                              "hmdb:HMDB0000935",
+                              "hmdb:HMDB0002755",
+                              "hmdb:HMDB0004369"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "homologene": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "HomoloGene"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>\\d+)$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/homologene/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00101"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Ortholog"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            ["117", "17", "6", "142", "55", "132", "61", "109", "137", "134"]
+                          ]
+                        }
+                      }
+                    },
+                    "hp": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "Human Phenotype Ontology"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^HP[:_](?<id>\\d{7})$"
+                        },
+                        "format": {
+                          "type": "string",
+                          "example": ["HP:%s", "HP_%s"]
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://purl.obolibrary.org/obo/HP_"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc02559"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Disease"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "HP:0001947",
+                              "HP:0031592",
+                              "HP:0012085",
+                              "HP:0000956",
+                              "HP:0025238",
+                              "HP:0002861",
+                              "HP:0001680",
+                              "HP:0004417",
+                              "HP:0001701",
+                              "HP:0025084"
+                            ],
+                            [
+                              "HP_0001947",
+                              "HP_0031592",
+                              "HP_0012085",
+                              "HP_0000956",
+                              "HP_0025238",
+                              "HP_0002861",
+                              "HP_0001680",
+                              "HP_0004417",
+                              "HP_0001701",
+                              "HP_0025084"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "human_protein_atlas": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "Human Protein Atlas"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>ENSG\\d{11})$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://www.proteinatlas.org/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00905"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Protein"
+                        }
+                      }
+                    },
+                    "inchi_key": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "InChIKey"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>[A-Z]{14}\\-[A-Z]{10}(\\-[A-Z])?)$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "https://identifiers.org/inchikey/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "FIXME"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Compound"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "RYYVLZVUVIJVGH-UHFFFAOYSA-N",
+                              "RZWGTXHSYZGXKF-UHFFFAOYSA-N",
+                              "RQQIIXFYTHWFKW-ZETCQYMHSA-N",
+                              "RALAARQREFCZJO-UHFFFAOYSA-N",
+                              "HVFRJJDZWVSUIB-UHFFFAOYSA-N",
+                              "KVNZVXVZQFTXNA-UHFFFAOYSA-N",
+                              "KVQUJTYBWCGJRS-UHFFFAOYSA-N",
+                              "AFGLQVAJWVTAJT-UHFFFAOYSA-N",
+                              "LHISABQPMWXWCC-UHFFFAOYSA-N",
+                              "ZSXCHLJCWRSMMS-UHFFFAOYSA-N"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "insdc": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "GenBank/ENA/DDBJ"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?:insdc:)?(?<id>[A-Z]\\d{5}|[A-Z]{2}\\d{6}|[A-Z]{4}\\d{8}|[A-J][A-Z]{2}\\d{5}|[A-Z]{4,}\\d{9})(?:\\.\\d+)?$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/insdc/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc02567"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Gene"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "U10991",
+                              "AF116914",
+                              "AK056978",
+                              "DQ440258",
+                              "U91725",
+                              "AY301270",
+                              "U32907",
+                              "AY261360",
+                              "AK001332",
+                              "U13261"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "intact": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "IntAct"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>EBI\\-[0-9]+)$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/intact/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00507"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Interaction"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "EBI-7947422",
+                              "EBI-15714708",
+                              "EBI-16225271",
+                              "EBI-4406290",
+                              "EBI-9026465",
+                              "EBI-6403471",
+                              "EBI-1113651",
+                              "EBI-562824",
+                              "EBI-9014072",
+                              "EBI-1784742"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "interpro": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "InterPro"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>IPR\\d{6})$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/interpro/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00108"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Domain"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "IPR038152",
+                              "IPR040448",
+                              "IPR036748",
+                              "IPR034266",
+                              "IPR005479",
+                              "IPR036365",
+                              "IPR000174",
+                              "IPR001334",
+                              "IPR000731",
+                              "IPR001767"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "kegg_compound": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "KEGG Compound"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>C\\d+)$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/kegg.compound/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00814"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Compound"
+                        }
+                      }
+                    },
+                    "kegg_disease": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "KEGG Disease"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^KEGG:H(?<id>\\d+)$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/kegg.disease/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00813"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Disease"
+                        }
+                      }
+                    },
+                    "kegg_drug": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "KEGG Drug"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>D\\d+)$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/kegg.drug/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00812"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Drug"
+                        }
+                      }
+                    },
+                    "kegg_genes": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "KEGG Genes"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^\\w+:[\\w\\d\\.-]*$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/kegg.genes/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00532"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Gene, Protein"
+                        }
+                      }
+                    },
+                    "kegg_orthology": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "KEGG Orthology"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>K\\d+)$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/kegg.orthology/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00817"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Ortholog"
+                        }
+                      }
+                    },
+                    "kegg_pathway": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "KEGG Pathway"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>\\w{2,4}\\d{5})$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/kegg.pathway/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00118"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Pathway"
+                        }
+                      }
+                    },
+                    "kegg_reaction": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "KEGG Reaction"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>R\\d+)$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/kegg.reaction/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00818"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Interaction"
+                        }
+                      }
+                    },
+                    "lrg": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "LRG"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>LRG_\\d+)$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/lrg/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc02566"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Gene"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "LRG_41",
+                              "LRG_356",
+                              "LRG_147",
+                              "LRG_660",
+                              "LRG_498",
+                              "LRG_364",
+                              "LRG_203",
+                              "LRG_162",
+                              "LRG_1271",
+                              "LRG_884"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "mbgd_gene": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "MBGD gene"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>[a-z0-9]+:[A-Z0-9_\\.-]+)$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://mbgd.genome.ad.jp/rdf/resource/gene/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00130"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Gene"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "ash:AL1_RS04670",
+                              "ash:AL1_RS08245",
+                              "ash:AL1_RS02870",
+                              "ash:AL1_RS06610",
+                              "ash:AL1_RS06290",
+                              "ash:AL1_RS07260",
+                              "ash:AL1_RS08410",
+                              "ash:AL1_RS01705",
+                              "ash:AL1_RS02510",
+                              "ash:AL1_RS07245"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "mbgd_organism": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "MBGD organism"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>[a-z0-9]+)$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://mbgd.genome.ad.jp/rdf/resource/organism/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00130"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Taxonomy"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            ["lac", "pfl", "cou", "bvn", "btd", "ctjt", "sha", "lmoj", "dpi", "arp"]
+                          ]
+                        }
+                      }
+                    },
+                    "meddra": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "MedDRA"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?:(?:MedDRA|meddra):)?(?<id>\\d+)$"
+                        },
+                        "format": {
+                          "type": "string",
+                          "example": ["%s", "MedDRA:%s", "meddra:%s"]
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/meddra/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc02564"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Disease"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "10008033",
+                              "10027710",
+                              "10062506",
+                              "10040493",
+                              "10013611",
+                              "10065857",
+                              "10063143",
+                              "10022599",
+                              "10042342",
+                              "10047883"
+                            ],
+                            [
+                              "MedDRA:10008033",
+                              "MedDRA:10027710",
+                              "MedDRA:10062506",
+                              "MedDRA:10040493",
+                              "MedDRA:10013611",
+                              "MedDRA:10065857",
+                              "MedDRA:10063143",
+                              "MedDRA:10022599",
+                              "MedDRA:10042342",
+                              "MedDRA:10047883"
+                            ],
+                            [
+                              "meddra:10008033",
+                              "meddra:10027710",
+                              "meddra:10062506",
+                              "meddra:10040493",
+                              "meddra:10013611",
+                              "meddra:10065857",
+                              "meddra:10063143",
+                              "meddra:10022599",
+                              "meddra:10042342",
+                              "meddra:10047883"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "medgen": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "MedGen"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>CN?\\d{4,7})$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/medgen/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc02560"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Disease"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "C0264897",
+                              "C0028860",
+                              "C0018818",
+                              "C1848392",
+                              "C0006389",
+                              "C0020517",
+                              "C0000364",
+                              "CN227118",
+                              "CN203043",
+                              "CN292950"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "mesh": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "MeSH"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>[CD]\\d{6,9})$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/mesh/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00132"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Disease"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "D002065",
+                              "C562829",
+                              "C566582",
+                              "D010623",
+                              "D003327",
+                              "D001715",
+                              "D000453",
+                              "D010260",
+                              "C537322",
+                              "C563418"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "mgi": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "MGI"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?:MGI|mgi):(?<id>\\d{5,})$"
+                        },
+                        "format": {
+                          "type": "string",
+                          "example": ["MGI:%s", "mgi:%s"]
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/mgi/MGI:"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00135"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Gene"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "MGI:2387184",
+                              "MGI:1920977",
+                              "MGI:2442415",
+                              "MGI:1098644",
+                              "MGI:1196250",
+                              "MGI:1914934",
+                              "MGI:1914238",
+                              "MGI:1919300",
+                              "MGI:1914807",
+                              "MGI:2145261"
+                            ],
+                            [
+                              "mgi:2387184",
+                              "mgi:1920977",
+                              "mgi:2442415",
+                              "mgi:1098644",
+                              "mgi:1196250",
+                              "mgi:1914934",
+                              "mgi:1914238",
+                              "mgi:1919300",
+                              "mgi:1914807",
+                              "mgi:2145261"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "mirbase": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "miRBase"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>MI\\d{7})$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/mirbase/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00136"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Transcript"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "MI0003587",
+                              "MI0000252",
+                              "MI0000811",
+                              "MI0014201",
+                              "MI0003578",
+                              "MI0000293",
+                              "MI0006384",
+                              "MI0006361",
+                              "MI0000480",
+                              "MI0006419"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "mondo": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "MONDO"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^MONDO[:_](?<id>\\d{7})$"
+                        },
+                        "format": {
+                          "type": "string",
+                          "example": ["MONDO:%s", "MONDO_%s"]
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://purl.obolibrary.org/obo/MONDO_"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc02563"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Disease"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "MONDO:0000115",
+                              "MONDO:0002345",
+                              "MONDO:0011571",
+                              "MONDO:0020035",
+                              "MONDO:0020920",
+                              "MONDO:0004627",
+                              "MONDO:0005480",
+                              "MONDO:0010852",
+                              "MONDO:0002053",
+                              "MONDO:0015758"
+                            ],
+                            [
+                              "MONDO_0000115",
+                              "MONDO_0002345",
+                              "MONDO_0011571",
+                              "MONDO_0020035",
+                              "MONDO_0020920",
+                              "MONDO_0004627",
+                              "MONDO_0005480",
+                              "MONDO_0010852",
+                              "MONDO_0002053",
+                              "MONDO_0015758"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "nando": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "NANDO"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^NANDO[:_](?<id>\\d{7})$"
+                        },
+                        "format": {
+                          "type": "string",
+                          "example": ["NANDO:%s", "NANDO_%s"]
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://nanbyodata.jp/ontology/NANDO_"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc02557"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Disease"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "NANDO:1200461",
+                              "NANDO:1200466",
+                              "NANDO:1200851",
+                              "NANDO:1200061",
+                              "NANDO:1200315",
+                              "NANDO:1200365",
+                              "NANDO:1200922",
+                              "NANDO:1200705",
+                              "NANDO:2200074",
+                              "NANDO:1200030"
+                            ],
+                            [
+                              "NANDO_1200461",
+                              "NANDO_1200466",
+                              "NANDO_1200851",
+                              "NANDO_1200061",
+                              "NANDO_1200315",
+                              "NANDO_1200365",
+                              "NANDO_1200922",
+                              "NANDO_1200705",
+                              "NANDO_2200074",
+                              "NANDO_1200030"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "ncbigene": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "NCBI gene"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>\\d+)$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/ncbigene/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00073"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Gene"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "63962027",
+                              "1046",
+                              "63961921",
+                              "102606930",
+                              "100472895",
+                              "407025",
+                              "84148",
+                              "88",
+                              "31157",
+                              "100463227"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "ncbiprotein": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "NCBI protein"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?:(?:\\w+\\d+(?:\\.\\d+)?)|(?:NP_\\d+))$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/ncbiprotein/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00584"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Protein"
+                        }
+                      }
+                    },
+                    "oma_group": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "OMA group"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>[A-Z]+)$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/oma.grp/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc02221"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Ortholog"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "RVAAYKY",
+                              "LFVHAIL",
+                              "EMSPITC",
+                              "NQSHFFA",
+                              "AYTHYSY",
+                              "PRPKYDP",
+                              "WSRIHIV",
+                              "DFGGWKI",
+                              "FHVAHGE",
+                              "PYVYVTH"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "oma_protein": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "OMA protein"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>[A-Z]{3}[A-Z0-9]{2}[0-9]{5,6})$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/oma.protein/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc02221"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Protein"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "ACIB400217",
+                              "ACIB400465",
+                              "HUMAN00333",
+                              "HUMAN01170",
+                              "HUMAN00470",
+                              "HUMAN03367",
+                              "ACIB400486",
+                              "HUMAN01061",
+                              "HUMAN02190",
+                              "HUMAN02112"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "omim_gene": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "OMIM gene"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?:O?MIM:)?(?<id>\\d{6})$"
+                        },
+                        "format": {
+                          "type": "string",
+                          "example": ["%s", "OMIM:%s", "MIM:%s"]
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/mim/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00154"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Gene"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "604810",
+                              "115460",
+                              "608706",
+                              "300181",
+                              "102575",
+                              "601280",
+                              "602832",
+                              "601604",
+                              "177075",
+                              "608977"
+                            ],
+                            [
+                              "OMIM:604810",
+                              "OMIM:115460",
+                              "OMIM:608706",
+                              "OMIM:300181",
+                              "OMIM:102575",
+                              "OMIM:601280",
+                              "OMIM:602832",
+                              "OMIM:601604",
+                              "OMIM:177075",
+                              "OMIM:608977"
+                            ],
+                            [
+                              "MIM:604810",
+                              "MIM:115460",
+                              "MIM:608706",
+                              "MIM:300181",
+                              "MIM:102575",
+                              "MIM:601280",
+                              "MIM:602832",
+                              "MIM:601604",
+                              "MIM:177075",
+                              "MIM:608977"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "omim_phenotype": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "OMIM phenotype"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?:O?MIM:)?(?<id>\\d{6})$"
+                        },
+                        "format": {
+                          "type": "string",
+                          "example": ["%s", "OMIM:%s", "MIM:%s"]
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/mim/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00154"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Disease"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "207780",
+                              "236100",
+                              "237500",
+                              "300716",
+                              "125310",
+                              "165199",
+                              "617175",
+                              "137600",
+                              "600089",
+                              "601317"
+                            ],
+                            [
+                              "OMIM:207780",
+                              "OMIM:236100",
+                              "OMIM:237500",
+                              "OMIM:300716",
+                              "OMIM:125310",
+                              "OMIM:165199",
+                              "OMIM:617175",
+                              "OMIM:137600",
+                              "OMIM:600089",
+                              "OMIM:601317"
+                            ],
+                            [
+                              "MIM:207780",
+                              "MIM:236100",
+                              "MIM:237500",
+                              "MIM:300716",
+                              "MIM:125310",
+                              "MIM:165199",
+                              "MIM:617175",
+                              "MIM:137600",
+                              "MIM:600089",
+                              "MIM:601317"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "orphanet": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "Orphanet"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?:ORPHA|ORDO|Orphanet)[:_](?<id>[A-Z0-9]+)$"
+                        },
+                        "format": {
+                          "type": "string",
+                          "example": ["ORPHA:%s", "ORDO:%s", "Orphanet:%s", "Orphanet_%s"]
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/orphanet.ordo/Orphanet_"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc01422"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Disease"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "ORPHA:101078",
+                              "ORPHA:596",
+                              "ORPHA:1934",
+                              "ORPHA:1047",
+                              "ORPHA:60025",
+                              "ORPHA:166090",
+                              "ORPHA:275745",
+                              "ORPHA:1171",
+                              "ORPHA:93277",
+                              "ORPHA:247598"
+                            ],
+                            [
+                              "ORDO:101078",
+                              "ORDO:596",
+                              "ORDO:1934",
+                              "ORDO:1047",
+                              "ORDO:60025",
+                              "ORDO:166090",
+                              "ORDO:275745",
+                              "ORDO:1171",
+                              "ORDO:93277",
+                              "ORDO:247598"
+                            ],
+                            [
+                              "Orphanet:101078",
+                              "Orphanet:596",
+                              "Orphanet:1934",
+                              "Orphanet:1047",
+                              "Orphanet:60025",
+                              "Orphanet:166090",
+                              "Orphanet:275745",
+                              "Orphanet:1171",
+                              "Orphanet:93277",
+                              "Orphanet:247598"
+                            ],
+                            [
+                              "Orphanet_101078",
+                              "Orphanet_596",
+                              "Orphanet_1934",
+                              "Orphanet_1047",
+                              "Orphanet_60025",
+                              "Orphanet_166090",
+                              "Orphanet_275745",
+                              "Orphanet_1171",
+                              "Orphanet_93277",
+                              "Orphanet_247598"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "pdb": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "PDB"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>[0-9][A-Za-z0-9]{3})$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://rdf.wwpdb.org/pdb/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00156"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Structure"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "3PFQ",
+                              "2OUY",
+                              "6EBX",
+                              "5GHP",
+                              "6ETH",
+                              "1Y28",
+                              "6FB2",
+                              "5JO3",
+                              "2JQZ",
+                              "5L5P"
+                            ],
+                            [
+                              "3pfq",
+                              "2ouy",
+                              "6ebx",
+                              "5ghp",
+                              "6eth",
+                              "1y28",
+                              "6fb2",
+                              "5jo3",
+                              "2jqz",
+                              "5l5p"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "pfam": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "Pfam"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>PF\\d{5})$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/pfam/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00163"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Domain"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "PF03719",
+                              "PF03726",
+                              "PF02809",
+                              "PF00105",
+                              "PF00250",
+                              "PF00412",
+                              "PF01412",
+                              "PF00459",
+                              "PF02532",
+                              "PF01226"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "pubchem_compound": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "PubChem compound"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?:CID)?(?<id>\\d+)$"
+                        },
+                        "format": {
+                          "type": "string",
+                          "example": ["%s", "CID%s"]
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/pubchem.compound/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00641"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Compound"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "9548669",
+                              "160419",
+                              "9869929",
+                              "76333303",
+                              "9868491",
+                              "27854",
+                              "76329169",
+                              "3448",
+                              "296",
+                              "10371227"
+                            ],
+                            [
+                              "CID9548669",
+                              "CID160419",
+                              "CID9869929",
+                              "CID76333303",
+                              "CID9868491",
+                              "CID27854",
+                              "CID76329169",
+                              "CID3448",
+                              "CID296",
+                              "CID10371227"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "pubchem_substance": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "PubChem substance"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?:SID)?(?<id>\\d+)$"
+                        },
+                        "format": {
+                          "type": "string",
+                          "example": ["%s", "SID%s"]
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/pubchem.substance/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00642"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Compound"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "15229855",
+                              "15277848",
+                              "15782795",
+                              "16076657",
+                              "16035895",
+                              "12012900",
+                              "15378994",
+                              "14850434",
+                              "14847540",
+                              "15271473"
+                            ],
+                            [
+                              "SID15229855",
+                              "SID15277848",
+                              "SID15782795",
+                              "SID16076657",
+                              "SID16035895",
+                              "SID12012900",
+                              "SID15378994",
+                              "SID14850434",
+                              "SID14847540",
+                              "SID15271473"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "pubmed": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "PubMed"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?:pmid:|PMID:)?(?<id>\\d+)$"
+                        },
+                        "format": {
+                          "type": "string",
+                          "example": ["%s", "pmid:%s", "PMID:%s"]
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/pubmed/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00179"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Literature"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "19281226",
+                              "19879151",
+                              "20858243",
+                              "10773016",
+                              "16527252",
+                              "28499733",
+                              "10397770",
+                              "15149666",
+                              "23861362",
+                              "10577920"
+                            ],
+                            [
+                              "pmid:19281226",
+                              "pmid:19879151",
+                              "pmid:20858243",
+                              "pmid:10773016",
+                              "pmid:16527252",
+                              "pmid:28499733",
+                              "pmid:10397770",
+                              "pmid:15149666",
+                              "pmid:23861362",
+                              "pmid:10577920"
+                            ],
+                            [
+                              "PMID:19281226",
+                              "PMID:19879151",
+                              "PMID:20858243",
+                              "PMID:10773016",
+                              "PMID:16527252",
+                              "PMID:28499733",
+                              "PMID:10397770",
+                              "PMID:15149666",
+                              "PMID:23861362",
+                              "PMID:10577920"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "reactome_pathway": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "Reactome pathway"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>R-[A-Z]{3}-\\d+)(?:\\.\\d+)?$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/reactome/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00185"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Pathway"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "R-HSA-165159",
+                              "R-DRE-1630316",
+                              "R-SCE-9634635",
+                              "R-DRE-140834",
+                              "R-HSA-2142753",
+                              "R-BTA-383280",
+                              "R-MMU-5218900",
+                              "R-RNO-5654219",
+                              "R-MMU-8875791",
+                              "R-MMU-9648025"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "reactome_reaction": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "Reactome reaction"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>R-[A-Z]{3}-\\d+)(?:\\.\\d+)?$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/reactome/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00185"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Reaction"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "R-DRE-1482961",
+                              "R-DRE-6814409",
+                              "R-HSA-2395869",
+                              "R-HSA-1222722",
+                              "R-HSA-893583",
+                              "R-MMU-158484",
+                              "R-HSA-8875071",
+                              "R-HSA-372519",
+                              "R-HSA-6797627",
+                              "R-DRE-975814"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "refseq_genomic": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "RefSeq genomic"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>(?:AC_|N[CGTW]_|NZ_[A-Z]+)\\d+)(?:\\.\\d+)?$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/refseq/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00187"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Gene"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "NG_004671",
+                              "NG_011844",
+                              "NG_008481",
+                              "NG_007973",
+                              "NG_001091",
+                              "NG_008005",
+                              "NG_023230",
+                              "NG_046394",
+                              "NG_009617",
+                              "NG_016421",
+                              "NG_021472"
+                            ],
+                            [
+                              "NG_004671.3",
+                              "NG_011844.2",
+                              "NG_008481.4",
+                              "NG_007973.1",
+                              "NG_001091.7",
+                              "NG_008005.1",
+                              "NG_023230.1",
+                              "NG_046394.1",
+                              "NG_009617.1",
+                              "NG_016421.2",
+                              "NG_021472.2"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "refseq_protein": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "RefSeq protein"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>[ANXYWZ]P_\\d+)(?:\\.\\d+)?$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/refseq/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00187"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Protein"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "NP_001171968",
+                              "NP_001365494",
+                              "NP_000015",
+                              "XP_011522750",
+                              "XP_011516190",
+                              "XP_005265876",
+                              "WP_016919164",
+                              "WP_080513319",
+                              "YP_001687722",
+                              "YP_001966380"
+                            ],
+                            [
+                              "NP_001171968.1",
+                              "NP_001365494.1",
+                              "NP_000015.2",
+                              "XP_011522750.1",
+                              "XP_011516190.1",
+                              "XP_005265876.1",
+                              "WP_016919164.1",
+                              "WP_080513319.1",
+                              "YP_001687722.1",
+                              "YP_001966380.1"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "refseq_rna": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "RefSeq RNA"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>(?:NM|NR|XM|XR)_\\d+)(?:\\.\\d+)?$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/refseq/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00187"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Transcript"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "XR_001747779",
+                              "XM_017013006",
+                              "NM_001199636",
+                              "XM_011532496",
+                              "NM_001110",
+                              "NR_170162",
+                              "NM_020113",
+                              "NM_001031805",
+                              "NR_027673",
+                              "XR_934019"
+                            ],
+                            [
+                              "XR_001747779.1",
+                              "XM_017013006.1",
+                              "NM_001199636.2",
+                              "XM_011532496.1",
+                              "NM_001110.4",
+                              "NR_170162.1",
+                              "NM_020113.3",
+                              "NM_001031805.1",
+                              "NR_027673.1",
+                              "XR_934019.3"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "rgd": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "RGD"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?:(?:RGD|rgd):)?(?<id>\\d{4,})$"
+                        },
+                        "format": {
+                          "type": "string",
+                          "example": ["%s", "RGD:%s", "rgd:%s"]
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/rgd/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00188"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Gene"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "1308312",
+                              "1311120",
+                              "1309724",
+                              "1565514",
+                              "7683241",
+                              "1307957",
+                              "71036",
+                              "1307876",
+                              "1308965",
+                              "1305482"
+                            ],
+                            [
+                              "RGD:1308312",
+                              "RGD:1311120",
+                              "RGD:1309724",
+                              "RGD:1565514",
+                              "RGD:7683241",
+                              "RGD:1307957",
+                              "RGD:71036",
+                              "RGD:1307876",
+                              "RGD:1308965",
+                              "RGD:1305482"
+                            ],
+                            [
+                              "rgd:1308312",
+                              "rgd:1311120",
+                              "rgd:1309724",
+                              "rgd:1565514",
+                              "rgd:7683241",
+                              "rgd:1307957",
+                              "rgd:71036",
+                              "rgd:1307876",
+                              "rgd:1308965",
+                              "rgd:1305482"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "rhea": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "Rhea"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>\\d{5})$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/rhea/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc02083"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Reaction"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "10253",
+                              "10818",
+                              "13517",
+                              "11136",
+                              "13729",
+                              "10240",
+                              "11728",
+                              "16870",
+                              "10732",
+                              "11278"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "sra_accession": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "SRA accession"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>[SED]RA\\d+)$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/insdc.sra/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00687"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Submission"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "DRA000741",
+                              "DRA000768",
+                              "DRA001014",
+                              "DRA000833",
+                              "SRA000144",
+                              "SRA000605",
+                              "SRA008879",
+                              "ERA007227",
+                              "ERA011638",
+                              "ERA013580"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "sra_analysis": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "SRA analysis"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>[SED]RZ\\d+)$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/insdc.sra/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00687"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Analysis"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "DRZ000249",
+                              "DRZ000087",
+                              "DRZ003045",
+                              "DRZ000829",
+                              "SRZ168127",
+                              "SRZ008405",
+                              "SRZ010259",
+                              "SRZ011419",
+                              "SRZ006662",
+                              "SRZ010567"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "sra_experiment": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "SRA experiment"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>[SED]RX\\d+)$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/insdc.sra/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00687"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Experiment"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "DRX000585",
+                              "DRX000114",
+                              "DRX000613",
+                              "DRX000681",
+                              "SRX000921",
+                              "SRX000254",
+                              "SRX000626",
+                              "ERX149204",
+                              "ERX001260",
+                              "ERX000427"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "sra_project": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "SRA project"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>[SED]RP\\d+)$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/insdc.sra/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00687"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Project"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "DRP000994",
+                              "DRP000877",
+                              "DRP000649",
+                              "DRP000147",
+                              "SRP266466",
+                              "SRP297268",
+                              "SRP000065",
+                              "ERP001266",
+                              "ERP007720",
+                              "ERP104141"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "sra_run": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "SRA run"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>[SED]RR\\d+)$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/insdc.sra/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00687"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "SequenceRun"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "DRR000834",
+                              "DRR000683",
+                              "DRR000264",
+                              "DRR000453",
+                              "SRR029947",
+                              "SRR000290",
+                              "SRR004854",
+                              "ERR499402",
+                              "ERR004130",
+                              "ERR000715"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "sra_sample": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "SRA sample"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>[SED]RS\\d+)$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/insdc.sra/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00687"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Sample"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "DRS001431",
+                              "DRS001371",
+                              "DRS000894",
+                              "DRS000386",
+                              "SRS2618009",
+                              "SRS7846025",
+                              "SRS000159",
+                              "ERS452503",
+                              "ERS000126",
+                              "ERS010423"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "taxonomy": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "Taxonomy"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>\\d+)$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/taxonomy/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00700"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Taxonomy"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "1171376",
+                              "484906",
+                              "1214242",
+                              "1124991",
+                              "1037911",
+                              "1266844",
+                              "243277",
+                              "696747",
+                              "263820",
+                              "713604"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "togovar": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "TogoVar variant"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>tgv\\d+)$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://togovar.biosciencedbc.jp/variation/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc02359"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Variant"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "tgv100005930",
+                              "tgv100000890",
+                              "tgv16331",
+                              "tgv10000341",
+                              "tgv21330879",
+                              "tgv15847",
+                              "tgv1354996",
+                              "tgv100002132",
+                              "tgv16568524",
+                              "tgv62035164"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "uniprot": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "UniProt"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?:(?<id1>[A-NR-Z][0-9](?:[A-Z][A-Z0-9][A-Z0-9][0-9]){1,2}(?:-\\d+)?)|(?<id2>[OPQ][0-9][A-Z0-9][A-Z0-9][A-Z0-9][0-9](?:-\\d+)?)(?:\\.\\d+)?)$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://purl.uniprot.org/uniprot/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00221"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Protein"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "A0A174V9D2",
+                              "A0A1V4U2Y9",
+                              "Q7NXD4",
+                              "P0AAM3",
+                              "O43423",
+                              "D4IJI4",
+                              "Q66SS1",
+                              "B5IDU9",
+                              "D3TBR4",
+                              "D4ILS5"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "uniprot_mnemonic": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "UniProt mnemonic"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>[A-Z0-9]+_[A-Z0-9]{0,5})$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://purl.uniprot.org/uniprot/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc00221"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Protein"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "2ABA_ORYSJ",
+                              "33K_ADES1",
+                              "1003L_ASFK5",
+                              "1A1D_VARPS",
+                              "1B02_GORGO",
+                              "1003L_ASFP4",
+                              "1433B_MACFA",
+                              "1107L_ASFWA",
+                              "3BHS1_MOUSE",
+                              "14331_SCHMA"
+                            ]
+                          ]
+                        }
+                      }
+                    },
+                    "wikipathways": {
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "example": "WikiPathways"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "example": "^(?<id>WP\\d{1,5})(?:\\_r\\d+)?$"
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "example": "http://identifiers.org/wikipathways/"
+                        },
+                        "catalog": {
+                          "type": "string",
+                          "example": "nbdc02116"
+                        },
+                        "category": {
+                          "type": "string",
+                          "example": "Pathway"
+                        },
+                        "examples": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            [
+                              "WP1531",
+                              "WP4312",
+                              "WP4877",
+                              "WP5020",
+                              "WP4400",
+                              "WP4474",
+                              "WP4183",
+                              "WP3650",
+                              "WP4545",
+                              "WP4462"
+                            ],
+                            [
+                              "WP1531_r107120",
+                              "WP4312_r104287",
+                              "WP4877_r116595",
+                              "WP5020_r114721",
+                              "WP4400_r108112",
+                              "WP4474_r102094",
+                              "WP4183_r106890",
+                              "WP3650_r110699",
+                              "WP4545_r116235",
+                              "WP4462_r102079"
+                            ]
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          }
+        }
+      }
+    },
+    "/config/dataset/{dataset}": {
+      "get": {
+        "tags": ["config"],
+        "summary": "Get selected dataset config",
+        "operationId": "getDataset",
+        "parameters": [
+          {
+            "name": "dataset",
+            "in": "path",
+            "description": "A key from https://github.com/dbcls/togoid-config/blob/main/config/dataset.yaml",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "label": {
+                      "type": "string",
+                      "example": "UniProt"
+                    },
+                    "regex": {
+                      "type": "string",
+                      "example": "^(?:(?<id1>[A-NR-Z][0-9](?:[A-Z][A-Z0-9][A-Z0-9][0-9]){1,2}(?:-\\d+)?)|(?<id2>[OPQ][0-9][A-Z0-9][A-Z0-9][A-Z0-9][0-9](?:-\\d+)?)(?:\\.\\d+)?)$"
+                    },
+                    "prefix": {
+                      "type": "string",
+                      "example": "http://purl.uniprot.org/uniprot/"
+                    },
+                    "catalog": {
+                      "type": "string",
+                      "example": "nbdc00221"
+                    },
+                    "category": {
+                      "type": "string",
+                      "example": "Protein"
+                    },
+                    "examples": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "example": [
+                          "A0A174V9D2",
+                          "A0A1V4U2Y9",
+                          "Q7NXD4",
+                          "P0AAM3",
+                          "O43423",
+                          "D4IJI4",
+                          "Q66SS1",
+                          "B5IDU9",
+                          "D3TBR4",
+                          "D4ILS5"
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          }
+        }
+      }
+    },
+    "/config/relation": {
+      "get": {
+        "tags": ["config"],
+        "summary": "Get all database relation",
+        "operationId": "getAllRelation",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "affy_probeset-ncbigene": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "detects"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is target of"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "chebi-inchi_key": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is represented as"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "represents"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "chembl_compound-chebi": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "chembl_compound-chembl_target": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "interacts with"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "interacts with"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "chembl_compound-drugbank": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "chembl_compound-hmdb": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "chembl_compound-inchi_key": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is represented as"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "represents"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "chembl_compound-mesh": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has related disease"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is related with"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "chembl_compound-pubchem_compound": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "chembl_compound-pubchem_substance": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "chembl_compound-pubmed": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has reference"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is reference of"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "chembl_target-ensembl_gene": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is product of gene"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has gene product"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "chembl_target-go": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has GO cellular component"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is GO cellular component of"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "chembl_target-interpro": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has protein domain"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is in protein"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "chembl_target-pdb": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has 3D structure"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is 3D structure of"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "chembl_target-pfam": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has protein domain"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is in protein"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "chembl_target-reactome_pathway": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "participates in pathway"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has participant molecule"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "chembl_target-uniprot": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "clinvar-medgen": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has related disease"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is related with"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "doid-mesh": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "doid-omim_phenotype": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "ensembl_gene-affy_probeset": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is target of"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "detects"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "ensembl_gene-ensembl_protein": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has gene product"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is product of gene"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "ensembl_gene-ensembl_transcript": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is transcribed to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is transcribed from"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "ensembl_gene-hgnc": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "ensembl_gene-ncbigene": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "ensembl_gene-uniprot": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has gene product"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is product of gene"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "ensembl_protein-ensembl_transcript": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is tranlated from"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is translated to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "ensembl_transcript-affy_probeset": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is target of"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "detects"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "ensembl_transcript-go": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has GO annotation"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is GO annotation of"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "ensembl_transcript-hgnc": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is transcribed from"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is transcribed to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "ensembl_transcript-refseq_rna": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "glytoucan-doid": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has related disease"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is related with"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "glytoucan-uniprot": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is attached to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is modified with"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "hgnc-ccds": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "hgnc-ec": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has EC number"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is EC number of"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "hgnc-ensembl_gene": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "hgnc-hgnc_symbol": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has synonym"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is synonym of"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "hgnc-insdc": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "hgnc-lrg": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "hgnc-mgi": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is orthologous to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is orthologous to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "hgnc-mirbase": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is transcribed to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is transcribed from"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "hgnc-ncbigene": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "hgnc-omim_gene": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "hgnc-pubmed": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has reference"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is reference of"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "hgnc-refseq_rna": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is transcribed to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is transcribed from"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "hgnc-rgd": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is orthologous to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is orthologous to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "hgnc-uniprot": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has gene product"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is product of gene"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "homologene-ncbigene": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has orthologous group member"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is member of orthologous group"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "interpro-go": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has GO annotation"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is GO annotation of"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "interpro-pdb": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is in structure"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has protein domain"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "interpro-pfam": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "interpro-pubmed": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has reference"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is reference of"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "interpro-reactome_pathway": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "participates in pathway"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has protein domain in pathway"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "interpro-uniprot": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is in protein"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has protein domain"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "mbgd_gene-uniprot": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has gene product"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is product of gene"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "mbgd_organism-taxonomy": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "medgen-hp": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "medgen-mesh": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "medgen-mondo": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "medgen-ncbigene": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is related with"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has related disease"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "medgen-omim_phenotype": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "medgen-orphanet": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "mondo-doid": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "mondo-hp": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "mondo-meddra": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "mondo-mesh": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "mondo-omim_phenotype": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "mondo-orphanet": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "nando-mondo": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "ncbigene-ensembl_gene": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "ncbigene-ensembl_protein": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has gene product"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is product of gene"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "ncbigene-ensembl_transcript": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is transcribed to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is transcribed from"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "ncbigene-go": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has GO annotation"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is GO annotation of"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "ncbigene-hgnc": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "ncbigene-mirbase": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is transcribed to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is transcribed from"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "ncbigene-omim_gene": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "ncbigene-refseq_genomic": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "ncbigene-refseq_protein": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has gene product"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is product of gene"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "ncbigene-refseq_rna": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is transcribed to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is transcribed from"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "ncbigene-taxonomy": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is gene of organism"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has gene"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "oma_protein-ensembl_gene": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is product of gene"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has gene product"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "oma_protein-ensembl_transcript": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is tranlated from"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is translated to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "oma_protein-uniprot": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "orphanet-meddra": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "orphanet-mesh": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "orphanet-omim_phenotype": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "pdb-go": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has GO annotation"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is GO annotation of"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "pdb-interpro": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has protein domain"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is in protein"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "pdb-pfam": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has protein domain"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is in protein"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "pdb-uniprot": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is 3D structure of"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has 3D structure"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "pubchem_compound-chebi": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "pubchem_compound-chembl_compound": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "pubchem_compound-drugbank": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "pubchem_compound-glytoucan": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "pubchem_compound-inchi_key": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is represented as"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "represents"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "reactome_pathway-go": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has GO biological process"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is GO biological process of"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "reactome_pathway-reactome_reaction": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has participant reaction"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "participates in pathway"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "reactome_reaction-chebi": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has participant molecule"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "participates in pathway"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "reactome_reaction-go": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has GO biological process"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is GO biological process of"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "reactome_reaction-uniprot": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has participant molecule"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "participates in pathway"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "refseq_protein-uniprot": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "refseq_rna-dbsnp": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has variant"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is located in"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "refseq_rna-hgnc": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is transcribed from"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is transcribed to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "refseq_rna-ncbigene": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is transcribed from"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is transcribed to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "refseq_rna-omim_gene": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is transcribed from"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is transcribed to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "refseq_rna-pubmed": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has reference"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is reference of"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "refseq_rna-refseq_protein": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is translated to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is tranlated from"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "refseq_rna-taxonomy": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is gene of organism"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has gene"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "rhea-chebi": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has participant molecule"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "participates in pathway"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "rhea-ec": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "rhea-reactome_reaction": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is nearly equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "sra_accession-bioproject": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "includes project"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "belongs to submission"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "sra_accession-biosample": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "includes sample"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "belongs to submission"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "sra_accession-sra_analysis": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "includes analysis"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "belongs to submission"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "sra_accession-sra_experiment": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "includes experiment"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "belongs to submission"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "sra_accession-sra_project": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "includes project"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "belongs to submission"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "sra_accession-sra_run": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "includes sequence run"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "belongs to submission"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "sra_accession-sra_sample": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "includes sample"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "belongs to submission"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "sra_experiment-bioproject": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "belongs to project"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "performs experiment"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "sra_experiment-biosample": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "captures sample"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is captured to perform experiment"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "sra_experiment-sra_project": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "belongs to project"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "performs experiment"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "sra_experiment-sra_sample": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "captures sample"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is captured to perform experiment"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "sra_project-bioproject": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "sra_run-bioproject": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "belongs to project"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "produces sequence run"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "sra_run-biosample": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is produced from sample"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is captured to produce sequence run"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "sra_run-sra_experiment": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is produced in experiment"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "produces sequence run"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "sra_run-sra_project": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "belongs to project"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "produces sequence run"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "sra_run-sra_sample": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is produced from sample"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is captured to produce sequence run"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "sra_sample-biosample": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "togovar-clinvar": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has clinical significance"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is clinical significance of"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "togovar-dbsnp": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has corresponding variant"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has corresponding variant"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "togovar-ensembl_gene": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is located in"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has variant"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "togovar-ensembl_transcript": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is located in"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has variant"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "togovar-hgnc": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is located in"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has variant"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "togovar-ncbigene": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is located in"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has variant"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "togovar-pubmed": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has reference"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is reference of"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "togovar-refseq_rna": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is located in"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has variant"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "uniprot-chembl_target": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "uniprot-dbsnp": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has variant"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is located in"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "uniprot-ec": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has EC number"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is EC number of"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "uniprot-ensembl_gene": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is product of gene"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has gene product"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "uniprot-ensembl_protein": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "uniprot-ensembl_transcript": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is tranlated from"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is translated to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "uniprot-go": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has GO annotation"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is GO annotation of"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "uniprot-hgnc": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is product of gene"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has gene product"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "uniprot-insdc": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is product of gene"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has gene product"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "uniprot-intact": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "participates in pathway"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has participant molecule"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "uniprot-ncbigene": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is product of gene"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has gene product"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "uniprot-oma_group": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is member of orthologous group"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has orthologous group member"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "uniprot-omim_gene": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is product of gene"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has gene product"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "uniprot-omim_phenotype": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has related disease"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is related with"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "uniprot-orphanet": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has related disease"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is related with"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "uniprot-pdb": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has 3D structure"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is 3D structure of"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "uniprot-pfam": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has protein domain"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is in protein"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "uniprot-reactome_pathway": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "participates in pathway"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has participant molecule"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "uniprot-refseq_protein": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is equivalent to"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is equivalent to"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "uniprot-uniprot_mnemonic": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has synonym"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is synonym of"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "wikipathways-chebi": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has participant molecule"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "participates in pathway"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "wikipathways-doid": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has related disease"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "is related with"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "wikipathways-uniprot": {
+                      "properties": {
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "forward": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "has participant molecule"
+                                }
+                              }
+                            },
+                            "reverse": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string",
+                                  "example": "participates in pathway"
+                                }
                               }
                             }
                           }
@@ -8357,60 +8283,66 @@
                   }
                 }
               }
-            },
-            "400": {
-              "description": "Bad request"
             }
+          },
+          "400": {
+            "description": "Bad request"
           }
         }
-      },
-      "/config/relation/{source}-{target}": {
-        "get": {
-          "tags": [
-            "config"
-          ],
-          "summary": "Get selected database relation",
-          "operationId": "getRelation",
-          "parameters": [
-            {
-              "name": "source",
-              "in": "path",
-              "type": "string",
-              "description": "A key from https://github.com/dbcls/togoid-config/blob/main/config/dataset.yaml",
-              "required": true
-            },
-            {
-              "name": "target",
-              "in": "path",
-              "type": "string",
-              "description": "A key from https://github.com/dbcls/togoid-config/blob/main/config/dataset.yaml",
-              "required": true
+      }
+    },
+    "/config/relation/{source}-{target}": {
+      "get": {
+        "tags": ["config"],
+        "summary": "Get selected database relation",
+        "operationId": "getRelation",
+        "parameters": [
+          {
+            "name": "source",
+            "in": "path",
+            "description": "A key from https://github.com/dbcls/togoid-config/blob/main/config/dataset.yaml",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
-          ],
-          "responses": {
-            "200": {
-              "description": "successful operation",
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "link": {
-                    "type": "object",
-                    "properties": {
-                      "forward": {
-                        "type": "object",
-                        "properties": {
-                          "label": {
-                            "type": "string",
-                            "example": "is attached to"
+          },
+          {
+            "name": "target",
+            "in": "path",
+            "description": "A key from https://github.com/dbcls/togoid-config/blob/main/config/dataset.yaml",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "link": {
+                      "type": "object",
+                      "properties": {
+                        "forward": {
+                          "type": "object",
+                          "properties": {
+                            "label": {
+                              "type": "string",
+                              "example": "is attached to"
+                            }
                           }
-                        }
-                      },
-                      "reverse": {
-                        "type": "object",
-                        "properties": {
-                          "label": {
-                            "type": "string",
-                            "example": "is modified with"
+                        },
+                        "reverse": {
+                          "type": "object",
+                          "properties": {
+                            "label": {
+                              "type": "string",
+                              "example": "is modified with"
+                            }
                           }
                         }
                       }
@@ -8418,1669 +8350,1672 @@
                   }
                 }
               }
-            },
-            "400": {
-              "description": "Bad request"
             }
+          },
+          "400": {
+            "description": "Bad request"
           }
         }
-      },
-      "/config/descriptions": {
-        "get": {
-          "tags": [
-            "config"
-          ],
-          "summary": "Get database description",
-          "operationId": "getDescription",
-          "responses": {
-            "200": {
-              "description": "successful operation",
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "bioproject": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "BioProject is a database which collects the results of research projects under the umbrella of the project or initiative. The database consists of tables of projects, which users can search or browse to find all data outputs related to that project. Users can submit projects or download data via FTP."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "特定の組織やコンソーシアムにより立ち上げられたゲノムプロジェクトをはじめとする生命科学分野の各種プロジェクトを単位とし、そこから産生されたデータセットをまとめたデータベースです。産生された配列データに関しては完全決定配列（ドラフト、進行中を含む）、アセンブリ、アノテーション、マッピングなどの進捗状況が含まれています。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "BioProject (Formerly Genome Project)"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      }
-                    }
-                  },
-                  "biosample": {
-                    "type": "object"
-                  },
-                  "ccds": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "This database seeks to identify a core set of human and mouse protein coding regions of high quality that are consistently annotated."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "高品質で確実にアノテーション付けされたヒトとマウスのタンパク質コード領域のコアセットを集約し、提供しているデータベースです。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "CCDS"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      }
-                    }
-                  },
-                  "chebi": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "ChEBI is a collection of data on entities of biological interest.\nThis database concentrates on assembling data on smaller chemical compounds, such as atoms, molecules, ions, radicals etc. These should be produced in nature or be synthetic molecules affecting biological processes in living organisms.\nChEBI does not generally include molecules directly encoded by the genome.\nThe database contains 31,651 entries with annotations.\nA keyword search option is available.\nIn addition to this an advanced search option, which includes a structure drawing tool, is provided.\nThe ChEBI database can be searched individually or in combination with other databases."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "生命プロセスに介在する小分子化合物の辞典です。ゲノムに直接コード化されている分子（例：核酸、タンパク、ペプチド）はこのデータベースの対象外です。登録されているデータは、多数の情報源のデータを組み合わせ、冗長性を除いています。主な情報源はIntEnz(EBI)、KEGG COMPOUND、PDBeChem(EBI)、ChEMBL(EBI)です。 ChEBIオントロジー（化合物オントロジー）による分類情報と階層表示が特徴です。\n全てのエントリーにはデータの信頼性を示す★印がついています； 3つ星：ChEBIチームが手作業で注釈付けを行ったもの。2つ星：ChEMBLチームまたはデータ提供者が手作業で注釈付けを行ったもの。1つ星：情報源から自動的に取得した仮エントリーで、手作業での注釈付けが行われていないもの。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "ChEBI"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "European Bioinformatics Institute"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "European Bioinformatics Institute"
-                      }
-                    }
-                  },
-                  "chembl_compound": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "ChEMBL is a database for bioactive molecules. It collects information of small molecules, such as calculated properties (e.g. logP, Molecular Weight, Lipinski Parameters, etc.) and abstracted bioactivities (e.g. binding constants, pharmacology and ADMET data), and the target information. Metadata of assays for small molecule activities or assays for binding activities between small molecules and its targets are also provided."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "ChEMBLは創薬を目的とした生理活性をもつ化合物や小分子のデータベースです。化合物、核酸などの小分子と、そのターゲットやアッセイ情報を紐付けて収載しています。化合物や小分子の名称、分子式、分子量、標準SMILES、標準InChIなどの情報に加え、結合定数、ADMEデータなど生理活性に関する情報や、薬としての開発段階の情報などが付与されています。化合物を名称や構造で検索したり、ターゲットをタンパク質の名称で検索することができます。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "ChEMBL"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "EMBL-EBI"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "EMBL-EBI"
-                      }
-                    }
-                  },
-                  "chembl_target": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "ChEMBL is a database for bioactive molecules. It collects information of small molecules, such as calculated properties (e.g. logP, Molecular Weight, Lipinski Parameters, etc.) and abstracted bioactivities (e.g. binding constants, pharmacology and ADMET data), and the target information. Metadata of assays for small molecule activities or assays for binding activities between small molecules and its targets are also provided."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "ChEMBLは創薬を目的とした生理活性をもつ化合物や小分子のデータベースです。化合物、核酸などの小分子と、そのターゲットやアッセイ情報を紐付けて収載しています。化合物や小分子の名称、分子式、分子量、標準SMILES、標準InChIなどの情報に加え、結合定数、ADMEデータなど生理活性に関する情報や、薬としての開発段階の情報などが付与されています。化合物を名称や構造で検索したり、ターゲットをタンパク質の名称で検索することができます。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "ChEMBL"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "EMBL-EBI"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "EMBL-EBI"
-                      }
-                    }
-                  },
-                  "civic_gene": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "CIViC is a knowledgebase for Clinical Interpretation of Variants in Cancer. It has collected knowledge of the therapeutic, prognostic, diagnostic and predisposing relevance of inherited and somatic variants in cancer based on expert-crowdsourcing."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "CIViCは癌におけるバリアントの臨床的解釈のための知識ベースです。遺伝性および体細胞性の全てのタイプの癌におけるバリアント情報と、その治療、予後、診断、素因への関連性を、専門家によるクラウドソーシングの形式で収集しています。バリアント、遺伝子、疾患、薬、evidence情報が整理されています。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "CIVIC"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "The McDonnell Genome Institute, Washington University School of Medicine"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "The McDonnell Genome Institute, Washington University School of Medicine"
-                      }
-                    }
-                  },
-                  "clinvar": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "ClinVar is a freely available archive describing relationships between medically important variants and phenotypes. Submissions report human variation, interpretations of the relationship of that variation to human health, and the evidence supporting each interpretation. ClinVar is tightly coupled with dbSNP and dbVar, which maintain information about locations of variations on human assemblies, and also based on the phenotypic descriptions maintained in MedGen (http://www.ncbi.nlm.nih.gov/medgen). Each record contains the submitter, the variation and the phenotype. Furthermore, to facilitate evaluation of the medical importance of each variant, ClinVar aggregates submissions with the same variation/phenotype combination, adds value from other NCBI databases, and reports if there are conflicting clinical interpretations. Data in ClinVar are available in multiple formats, including html, download as XML, VCF or tab-delimited subsets."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "ヒトゲノムの多様性と関連する疾患についての情報を収集し、自由に利用できるアーカイブとして提供しているデータベースです。多型の位置、遺伝子名、疾患との関わりなどを収録しています。遺伝子情報はNCBIのdbSNPおよびdbVarと、表現型に関してはMedGenとリンクしています。また、NIH Genetic Testing Registry (GTR)、OMIM、PubMedからも情報を収集しています。各データはhtml形式での閲覧の他、XMLやタブ区切り形式、一部データはVCFファイルでダウンロードできます。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "ClinVar"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      }
-                    }
-                  },
-                  "dbsnp": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "dbSNP collects information on polymorphisms based on single and small-scale multi-base substitutions, including insertions and deletions, microsatelites, and non-polymorphic variants. Differences in the frequency of polymorphisms in a population can be visually compared for each SNP."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "1～数塩基の置換、挿入/欠失、反復等の多型情報からなるデータベースです。各SNPについて、集団間での多型頻度の違いを視覚的に比較することもできます。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "dbSNP"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      }
-                    }
-                  },
-                  "dgidb": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "DGIdb is a database about drug-gene interactions and the druggable genome. It collects and integrates drug-gene interactions and gene druggability information from papers, databases and web resources, such as DrugBank, PharmGKB, ChEMBL, Drug Target Commons, TTD, and others, using a combination of expert curation and text-mining. It consists of gene records for gene details, drug records for drug details and Interaction records for interaction of the genes and drugs. Users can enter a list of genes to retrieve all known or potentially druggable genes in that list. Results can be filtered by source, interaction type, or gene category."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "DGIdbは薬物と遺伝子の相互作用および創薬可能なゲノム資源に関するデータベースです。 DrugBank、PharmGKB、Chembl、Drug Target Commons、TTDなど、様々な論文、データベース、その他のWebリソースから、薬物と遺伝子の相互作用および遺伝子の創薬への適用可能性情報を専門家によるキュレーションとテキストマイニングにより整理・統合して提供しています。 薬に関するレコード、遺伝子に関するレコード、相互作用に関するレコードに分かれて整理されており、相互に参照できます。すべてのデータは、無料でダウンロードするか（＊ダウンロードページに条件が記載されている場合を除く）、APIを介してアクセスできます。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "DGiDB"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "McDonnell Genome Institute, Washington University School of Medicine"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "McDonnell Genome Institute, Washington University School of Medicine"
-                      }
-                    }
-                  },
-                  "doid": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "This site provides a Disease Ontology, which is a standardized ontology organized by human disease terms and related medical concepts. The DO terms are associated with MeSH, ICD, NCI's thesaurus, SNOMED and OMIM to integrate disease and medical vocabularies."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "ヒトの疾患に関する用語や概念について整理したDisease Ontologyを提供するサイトです。MeSH、ICD、NCI’s thesaurus、SNOMEDやOMIMへリンク付けられています。キーワードで語彙を検索することができます。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "DO"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "Institute of Genome Sciences, University of Maryland School of Medicine"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "Institute of Genome Sciences, University of Maryland School of Medicine"
-                      }
-                    }
-                  },
-                  "drugbank": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "DrugBank is a database of detailed informatics resources on approved and experimental drugs. The database contains informaiton on drug targets as well as the results of experiments resulting in extensive bioinformatics and chemoinformatics data. Users can browse or search by drug or target. Data is available for download."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "薬剤の化学的、薬理的、薬事的データとそのターゲット（配列、構造、パスウエイ）の詳細情報を収集、統合したバイオインフォマティクスおよびケモインフォマティクスのリソースです。薬剤エントリー約4,800件のうち、FDA承認小分子薬剤が1,350以上、FDA承認バイオテク（タンパク/ペプチド）薬剤123件、栄養補助食品71件、実験的薬剤が3,243件以上が含まれています。2,500以上の非冗長タンパク配列がFDA承認薬剤エントリーにリンクしています。各エントリーにつき100以上のデータ項目が存在します。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "DrugBank"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "University of Alberta/Department of Computing Science"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "University of Alberta/Department of Computing Science"
-                      }
-                    }
-                  },
-                  "ec": {
-                    "type": "object"
-                  },
-                  "ena": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "ENA is a database of data from global nucleotide sequencing projects. The database contains information on projects from raw phases trhough complete functional annotation. Users can search by keyword or DNA sequence. Bulk data is available for download."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "次世代シーケンサーによる配列データのレポジトリサイトです。サンプル、実験情報、機器情報、データとしては配列トレース、配列、クオリティ値を含み、アセンブル、マッピング、機能アノテーションも提供しています。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "ENA"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "European Bioinformatics Institute"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "European Bioinformatics Institute"
-                      }
-                    }
-                  },
-                  "ensembl_gene": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "ENSEMBL is a collection of automatically annotated genome databases for vertebrates and a number of eukaryotes, integrated with all other relevant biological data available.\r\nThe repository covers data on gene annotation, microarray probeset mapping and comparative genomics among many other topics.\r\nInformation may be downloaded by a variety of means: \r\nFor small amounts of data, an export option is suggested.\r\nFor larger amounts of data, an FTP site is provided from where a complete database may be downloaded in one of various formats, from flat files to MySQL dumps."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "ゲノム解読された脊椎生物およびその他の主要な真核生物を対象として自動アノテーションを行い、その結果をゲノムビューワやデータベースとして公開しているプロジェクトです。EMBL-EBIとSanger Centreが共同で進めています。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "Ensembl"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "Wellcome Trust Sanger Institute"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "Wellcome Trust Sanger Institute"
-                      }
-                    }
-                  },
-                  "ensembl_protein": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "ENSEMBL is a collection of automatically annotated genome databases for vertebrates and a number of eukaryotes, integrated with all other relevant biological data available.\r\nThe repository covers data on gene annotation, microarray probeset mapping and comparative genomics among many other topics.\r\nInformation may be downloaded by a variety of means: \r\nFor small amounts of data, an export option is suggested.\r\nFor larger amounts of data, an FTP site is provided from where a complete database may be downloaded in one of various formats, from flat files to MySQL dumps."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "ゲノム解読された脊椎生物およびその他の主要な真核生物を対象として自動アノテーションを行い、その結果をゲノムビューワやデータベースとして公開しているプロジェクトです。EMBL-EBIとSanger Centreが共同で進めています。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "Ensembl"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "Wellcome Trust Sanger Institute"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "Wellcome Trust Sanger Institute"
-                      }
-                    }
-                  },
-                  "ensembl_transcript": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "ENSEMBL is a collection of automatically annotated genome databases for vertebrates and a number of eukaryotes, integrated with all other relevant biological data available.\r\nThe repository covers data on gene annotation, microarray probeset mapping and comparative genomics among many other topics.\r\nInformation may be downloaded by a variety of means: \r\nFor small amounts of data, an export option is suggested.\r\nFor larger amounts of data, an FTP site is provided from where a complete database may be downloaded in one of various formats, from flat files to MySQL dumps."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "ゲノム解読された脊椎生物およびその他の主要な真核生物を対象として自動アノテーションを行い、その結果をゲノムビューワやデータベースとして公開しているプロジェクトです。EMBL-EBIとSanger Centreが共同で進めています。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "Ensembl"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "Wellcome Trust Sanger Institute"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "Wellcome Trust Sanger Institute"
-                      }
-                    }
-                  },
-                  "glytoucan": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "GlyTouCan is an international repository of glycan structures. This database contains uncurated glycan structures ranging in resolution from monosaccharide composition to fully defined structures, as long as there are no inconsistencies in the structure. The database allows users to search by text, graphic input or motif, and browse using motif-list or glycan-list."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "糖鎖構造データを収録した国際糖鎖構造リポジトリです。単糖類組成からグリコシド結合形状などの明確な構造まで、構造に不一致がない限り世界的にユニークなアクセッション番号を付けて登録することができます。キーワード、モチーフ、糖鎖構造画像からの検索、モチーフや糖鎖のリストからのブラウズが可能です。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "GlyTouCan"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "GlyTouCan Project Team"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "GlyTouCan Project Team"
-                      }
-                    }
-                  },
-                  "go": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "GO is a database which provides a controlled vocabulary of terms for describing gene product characteristics and gene product annotation data. It contains data of terms, definitions and ontology structure. The most recent version of the ontology and the annotation files contributed by members of the GO Consortium are available for download. The GO provides the AmiGO browser and search engine which are web browser-based access to the GO database."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "遺伝子オントロジー（Gene Ontology;GO）とは、生物学的概念を記述するための標準となる語彙を策定しようとするプロジェクトです。GOで定義された用語はGO Termと呼ばれ、Cellular component、Biological process、Molecular functionという3つのカテゴリーに分類されています。GOのデータは、非循環有向グラフ (Directed Acyclic Graph: DAG) と呼ばれるデータ構造を用いて計算機上で記述することができます。\nこのサイトでは、GO Termや関連ツールの配布を行っています。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "GO"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "The GO Consortium"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "The GO Consortium"
-                      }
-                    }
-                  },
-                  "hgnc": {
-                    "type": "object"
-                  },
-                  "hgnc_symbol": {
-                    "type": "object"
-                  },
-                  "hmdb": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "HUMDB is a database of human metabolites. The database contains information on thousands of metabolites produced by and found in the human body as a result of metabolic processes. genes and proteins related to the metabolites are also affiliated with records, where appropriate. Data on metabolites and the associated genes and proteins are available for download."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "ヒト体内における低分子代謝物の詳細情報を収集したデータベースです。メタボロミクスや臨床化学、バイオマーカー探索、教育分野で活用されることを目的に構築しており、化学データ、臨床データ、分子生物学/化学データを含んでいます。現在、7,900代謝物が登録されており、7,200のタンパク質（DNA）配列のリンク情報があります。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "HMDB"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "University of Alberta"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "University of Alberta"
-                      }
-                    }
-                  },
-                  "homologene": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "In Homologenes, users can find automatically constructed homologous gene sets from the full-length genome sequences of a wide range of eukaryotic species, as well as mRNA and protein sequences."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "全ゲノム配列が決定された20種類の真核生物の間で自動的検出したホモログ遺伝子のセット、およびmRNAやタンパク質の配列データを提供しています。他の生物種のUniGene配列でホモログの可能性があるものも表示されます。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "HomoloGene"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      }
-                    }
-                  },
-                  "hp": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "The Human Phenotype Ontology (HPO) provides a standardized vocabulary of phenotype specialized in human disease. The medical literatures, Orphanet, DECIPHER, and OMIM are used for developing the HPO."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "The Human Phenotype Ontology (HPO) はヒトの疾患に関連する形質の標準化された語彙を提供しています。医学論文、Orphanet、DECIPHER,やOMIMを基に開発されており、疾患と関連する形質の語彙や、疾患に関連する遺伝子情報が収載されています。疾患名、形質、遺伝子名で検索することができます。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "HPO"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "The Jackson Laboratory"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "The Jackson Laboratory"
-                      }
-                    }
-                  },
-                  "human_protein_atlas": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "Human Protein Atlas is a database of protein expression and localization. The database contains information on where proteins localize within cells and lists antibodies for the detection of human proteins. Information on expression in cancer lines as well as RNA transcript expression is also represented. Elements can be searched by several positional characteristics."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "様々な種類のヒトの器官、組織、細胞におけるタンパク質の発現および局在に関するデータベースです。蛍光抗体イメージング、質量分析に基づくプロテオミクス、網羅的な遺伝子発現解析によるトランスクリプトミクスおよびシステム生物学の手法により得られた情報を遺伝子ごとに記載しています。各レコードは３つのアトラスで構成されています。\n「組織アトラス」：ヒトの主要組織や器官におけるRNA発現量、タンパク質発現量\n「細胞アトラス」：RNA発現量や発現画像、GFP発現画像など細胞内での局在\n「疾病アトラス」：生存がん患者の組織における量的発現解析（RNA-seq）や空間的発現解析（マイクロアレイ）によるタンパク質発現レベル\nまた、抗体の情報、細胞内器官の説明、各組織における腫瘍の説明や生存率の情報なども収録しています。\n遺伝子名、抗体名、タンパク質の分類によるデータの絞り込みが可能です。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "Human Protein Atlas"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "Uppsala University"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "Uppsala University"
-                      }
-                    }
-                  },
-                  "inchi_key": {
-                    "type": "object"
-                  },
-                  "insdc": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "It is a portal site for the INSDC(International Nucleotide Sequence Database Collaboration), which is an initiative operated between DDBJ, EMBL-EBI and NCBI.  Each organization operates DNA databases in close coordination and cooperation with each other to achieve common accession numbers, and standardize data format (INSD-XML). The databases are called the International Nucleotide Sequence Databases (INSD)."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "本サイトは、３大DNAデータベースであるDDBJ、ENA(European Nucleotide Archive)、 NCBIの協力で運営されるINSDC(International Nucleotide Sequence Database Collaboration)のポータルサイトです。INSDCは連携して塩基配列のアクセションIDの共通化やデータ形式の統一(INSD-XML)などに取り組みながら、個々の拠点におけるWebサービスの開発が行われています。INSDCが連携して構築・運営しているデータベースは国際塩基配列データベース (International Nucleotide Sequence Databases, INSD) と呼ばれます。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "INSDC"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "European Bioinformatics Institute (EMBL-EBI)"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "European Bioinformatics Institute (EMBL-EBI)"
-                      }
-                    }
-                  },
-                  "intact": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "IntAct is a database of molecular interactions. The database contains information on more than 400,000 interactions gathered from primary literature. Users can search by gene, protein, or publication, among others, and the database includes manually annotated data from several other interaction databases. Software and bulk data, updoated weekly, are also available for download."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "IntActはオープンソースの分子間相互作用のデータベースとツールキットで構成されています。データは文献から取得したり、専門家によって蓄積されたデータから構成されています。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "IntAct"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "European Bioinformatics Institute"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "European Bioinformatics Institute"
-                      }
-                    }
-                  },
-                  "interpro": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "InterPro is a database that analyses proteins functionally and classifies them into families as well as predicts their domain and sites in the genome.\nThis repository harvests its content from a large number of related databases and consolidates its findings into a single searchable resource avoiding the occurrence of redundant entries.\nInterPro aims to update their content every 8 weeks.\nA keyword search is available and an option is provided where a protein sequence can be entered for analysis."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "EBI によるタンパク質のファミリー分類、ドメイン、機能サイトに関する記述を収集した統合データベースです。UniProtやPROSITE、PANTHER、ProDom、SMARTなどタンパク質の特性を収録している複数のデータベースを集結し、様々なレベルでのタンパク質の特徴を提供しています。InterProScanを用いて、ユーザが入力した配列から機能ドメインや構造ドメインを検索することができます。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "InterPro"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "European Bioinformatics Institute"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "European Bioinformatics Institute"
-                      }
-                    }
-                  },
-                  "kegg_compound": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "KEGG COMPOUND is a database of biologically relevant compounds, including chemical structures and associated information for compounds in the KEGG database such as small molecules, biopolymers, and other related substances. The site also has a collection of links to other relevant KEGG resources such as GLYCAN."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "KEGG COMPOUNDは、小分子、生体高分子、および生体関連化学物質のデータベースです。 各エントリーはC番号とよばれるアクセッション番号で識別され、化学構造や関連する生体反応、パスウエイ、他のデータベースとのリンク情報が含まれています。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "KEGG COMPOUND"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "Kyoto University Institute for Chemical Research Bioinformatics Center"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "京都大学　化学研究所　附属バイオインフォマティクスセンター"
-                      }
-                    }
-                  },
-                  "kegg_disease": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "KEGG DISEASE is a database of human diseases with information on perturbed molecular networks. Each disease entry contains a list of known disease genes, environmental factors (carcinogens, pathogens, etc), diagnostic markers and therapeutic drugs with reference information. This database provides maps of molecular networks associated with diseases through links to the KEGG PATHWAY database. Users can search human diseases by names, description, categories, pathways, and known causative genes."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "KEGG DISEASEは、遺伝要因が既知の疾患（単一遺伝子疾患及び多因子性疾患）と病原体ゲノムが既知の感染症疾患に関する情報を、計算処理が可能な形に集約したデータベースです。各疾患エントリは H番号とよばれるアクセッション番号で識別され、関連するパスウエイ、病因遺伝子のリスト、ならびに環境要因、診断マーカー、治療薬などの分子のリストで表現されています。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "KEGG DISEASE"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "Kyoto University Institute for Chemical Research Bioinformatics Center"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "京都大学　化学研究所　附属バイオインフォマティクスセンター"
-                      }
-                    }
-                  },
-                  "kegg_drug": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "KEGG DRUG is a comprehensive database of drug information about all marketed drugs in Japan, as well as many prescription drugs in USA and Europe. KEGG DRUG is based on chemical structure or component, and each entry contains information about drug targets (pathways), metabolizing enzymes and other interacting molecules. This database also includes crude drugs and TCM (Tradictional Chinese Medicine). Users can check for drug-drug interaction, view structure maps representing the history of drug development and search drugs by generic names, trade names, and components."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "KEGG DRUG は、日本、米国、欧州の医薬品情報を、化学構造と成分の観点から一元的に集約・管理したデータベースです。とくに日本の医薬品は医療用（処方薬）だけでなく一般用（大衆薬、OTC薬）もすべて網羅し、個々の製品情報（添付文書情報）へのリンクがつけられています。また化学薬品だけでなく、生薬・漢方方剤もデータベース化されています。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "KEGG DRUG"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "Kyoto University Institute for Chemical Research Bioinformatics Center"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "京都大学　化学研究所　附属バイオインフォマティクスセンター"
-                      }
-                    }
-                  },
-                  "kegg_genes": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "KEGG geneS is a catalog of gene information for multiple species with species-specified gene information for all species with complete genome sequences. The database references primary sources and provides pathway, ortholog, paralog, and motif searching functions. Results of gene searches include nucleotide and protein information."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "KEGG GENESは、全ゲノム配列が決定された生物種について、その遺伝子セットをRefSeq その他の公共データベースから自動生成し、KEGG 独自のアノテーション（KO アノテーション）を行っているデータベースです。\n以前、VGENES (http://integbio.jp/dbcatalog/record/nbdc00820) や VGENOME (http://integbio.jp/dbcatalog/record/nbdc00821) に収録されていたウィルスに関する情報も収録されています。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "KEGG GENES Database"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "Kyoto University Institute for Chemical Research Bioinformatics Center"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "京都大学　化学研究所　附属バイオインフォマティクスセンター"
-                      }
-                    }
-                  },
-                  "kegg_orthology": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "KEGG ORTHOLOGY is a database of KEGG pathway ortholog groups, and contains the pathways at the core of the KEGG representation system. Users can search for ortholog groups and explore members across species."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "KEGG ORTHOLOGYは、KEGGパスウェイの各ノードまたはBRITE機能階層の最下層ノードに対応したオーソロググループを手作業で定義したものです。ゲノム中の各遺伝子にKO識別子（K番号）を付与することで、KEGGパスウェイやBRITE機能階層へのマッピング（エンリッチメント）が可能となります。KOシステムは、ゲノムの情報からパスウェイ等高次生命システム情報を解読するための架け橋となります。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "KEGG ORTHOLOGY (KO) Database"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "Kyoto University Institute for Chemical Research Bioinformatics Center"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "京都大学　化学研究所　附属バイオインフォマティクスセンター"
-                      }
-                    }
-                  },
-                  "kegg_pathway": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "The KEGG PATHWAY database has manually drawn pathway maps that represent molecular interaction and reaction networks for the following: Global Map, Metabolism, genetic Information Processing, Cellular Processes, Organismal Systems, Human Diseases and also structure relationships in Drug Development. By using KEGG PATHWAY mapping, molecular datasets can be mapped for the biological interpretation of higher-level systemic functions."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "代謝、様々な細胞プロセス、ヒト疾患などに関する分子ネットワークの知識を表現したパスウェイマップを収録しています。マップは文献等から手作業で作成しています。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "KEGG PATHWAY Database"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "Kyoto University Institute for Chemical Research Bioinformatics Center"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "京都大学　化学研究所　附属バイオインフォマティクスセンター"
-                      }
-                    }
-                  },
-                  "kegg_reaction": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "KEGG REACTION is a database of enzymatic reactions. The database contains all KEGG enzyme interactions and KEGG pathway metabolic reactions, including related pathways, and uses IUBMB nomenclature. Users can also find the reaction pathway of individual enzymes."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "KEGG REACTIONは、KEGG ENZYMEに格納されているすべての反応と、KEGG PATHWAYの代謝パスウエイの反応を蓄積したデータベースです。 各反応はR番号によって識別され、 反応の構造式や関連する酵素のオーソロググループが収集されており、ゲノム(酵素遺伝子)情報と化学(化合物のペア)情報の統合解析を可能としています。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "KEGG REACTION"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "Kyoto University Institute for Chemical Research Bioinformatics Center"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "京都大学　化学研究所　附属バイオインフォマティクスセンター"
-                      }
-                    }
-                  },
-                  "lrg": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "LRG is a database of stable genomic, transcript and protein reference sequences for reporting clinically relevant sequence variants. NCBI (RefSeq) and EMBL-EBI (Ensembl/GENCODE) are working together to rationalise differences in their gene sets. Records contain information about genomic, transcript and protein sequences, annotations, maps about the genome assembly, etc. This database allows users to search using LRG identifier, HGNC gene name, NCBI and Ensembl accession numbers (gene or transcript), gene synonym or LRG status (public or pending). Genome browsers on Ensembl, NCBI and UCSC are available."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "ゲノム、転写産物、タンパク質のリファレンス配列のデータベースです。臨床に関連する変異配列を報告するためのリファレンス配列を、 NCBI（RefSeq）とEMBL-EBI（Ensembl / GENCODE）の協力により情報統合しています。 各レコードには、ゲノム、転写産物、タンパク質の配列、アノテーション、ゲノムアセンブリに関するマップなどが含まれています。LRG番号、HGNC遺伝子名、NCBIやEnsemblのID番号（遺伝子、転写産物）、遺伝子の同義語、公開非公開の別による絞り込みが可能です。また、Ensembl、NCBI、UCSCのゲノムブラウザが利用可能です。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "LRG"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "European Bioinformatics Institute (EMBL-EBI)"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "European Bioinformatics Institute (EMBL-EBI)"
-                      }
-                    }
-                  },
-                  "mbgd_gene": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "MBGD is a database with a workbench system for comparative analysis of completely sequenced microbial genomes, mainly for creating orthologous or homologous gene cluster tables. MBGD classifies genomes by the hierarchical clustering method known as UPGMA, using precomputed similarity relationships identified by all-against-all BLAST search. Users can change the set of organisms or cutoff parameters to create their own orthologous groupings. Thus comparative genomics is facilitated from various points of view such as ortholog identification, paralog clustering, motif analysis and gene order comparison."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "オーソログ解析に基づいて微生物ゲノムの比較解析を行うためのデータベースです。公開されたゲノム全体を含む標準オーソログテーブルに基づいて、各オーソロググループの系統プロファイルの比較などを行えるほか、動的なオーソログ解析機能によって、利用者自身が持つゲノム配列も含めて、興味のある生物種セットに対象を絞った比較を行うこともできます。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "MBGD"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "National Institute for Basic Biology"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "自然科学研究機構　基礎生物学研究所"
-                      }
-                    }
-                  },
-                  "mbgd_organism": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "MBGD is a database with a workbench system for comparative analysis of completely sequenced microbial genomes, mainly for creating orthologous or homologous gene cluster tables. MBGD classifies genomes by the hierarchical clustering method known as UPGMA, using precomputed similarity relationships identified by all-against-all BLAST search. Users can change the set of organisms or cutoff parameters to create their own orthologous groupings. Thus comparative genomics is facilitated from various points of view such as ortholog identification, paralog clustering, motif analysis and gene order comparison."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "オーソログ解析に基づいて微生物ゲノムの比較解析を行うためのデータベースです。公開されたゲノム全体を含む標準オーソログテーブルに基づいて、各オーソロググループの系統プロファイルの比較などを行えるほか、動的なオーソログ解析機能によって、利用者自身が持つゲノム配列も含めて、興味のある生物種セットに対象を絞った比較を行うこともできます。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "MBGD"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "National Institute for Basic Biology"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "自然科学研究機構　基礎生物学研究所"
-                      }
-                    }
-                  },
-                  "meddra": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "MedDRA is a standardized medical terminology for regulatory information of medical products. It is available for use in the registration, documentation and safety monitoring of medical products. It is provided in many languages, which are Chinese, Czech, Dutch, French, German, Hungarian, Italian, Japanese, Korean, Portuguese, Portuguese - Brazilian, Russian, and Spanish in addition to English Master."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "MedDRAは人間が使用する医薬品の規制情報を国際的に共有しやすくするために作成された、標準化された国際医療用語集です。英語版の他に、中国語、チェコ語、オランダ語、フランス語、ドイツ語、ハンガリー語、イタリア語、日本語、韓国語、ポルトガル語、ポルトガル語（ブラジル語）、ロシア語、スペイン語で提供されています。英国の医薬品医療製品規制庁（MHRA）に属する用語に基づいて、WHOを含むICHパートナーによって開発されました。サブスクリプションレベルにより有償・無償が異なります。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "MedDRA"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "The International Council for Harmonisation of Technical Requirements for Pharmaceuticals for Human Use (ICH)"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "医薬品規制調和国際会議（ICH）"
-                      }
-                    }
-                  },
-                  "medgen": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "MedGen is a portal database about conditions and phenotypes related to Medical Genetics. It aggregates terms from the NIH Genetic Testing Registry (GTR), UMLS, HPO, Orphanet, ClinVar and other sources into concepts, and assigns a unique identifier and a preferred name and symbol. Each entry includes names, identifiers used by other databases, mode of inheritance, clinical features, and map location of the loci affecting the disorder. This database provides links to such resources as:\nGenetic tests registered in the NIH Genetic Testing Registry (GTR), GeneReviews, ClinVar, OMIM, Related genes, Disorders with similar clinical features, Medical and research literature, Practice guidelines, Consumer resources, Ontologies such as HPO and ORDO."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "遺伝医学に関連する症状や表現型に関する情報を集約したポータルデータベースです。NIHのGTR、UMLS、HPO、Orphanet、ClinVar、その他のソースから得られた用語を概念に集約し、一意の識別子（CUI）と優先名を割り当てます。 各エントリーには、名称、他のデータベースで使用される識別子、遺伝様式、臨床的特徴、疾患に影響を与える遺伝子座の地図上の位置が含まれます。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "MedGen"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information (NCBI)"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information (NCBI)"
-                      }
-                    }
-                  },
-                  "mesh": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "This is a database of keywords representing the content of articles and biological information. The keywords are structured in layers to allow users to find more detailed information or perform abstract searches."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "文献や、生物学情報の内容を表すキーワードのデータベースです。このキーワードを利用することで関連する生物学情報を得ることができます。キーワードは階層構造をなしており、より詳細に情報をたどることも、より抽象的な検索をすることも可能です。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "MeSH"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      }
-                    }
-                  },
-                  "mgi": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "This is a comprehensive site for mouse research. The site contains detailed information on mouse genes, gene expression data, polymorphisms and mutations, pathways, data on model rats for hereditary cancers, and phenotypes of each mouse model system. They have developed and provided The Human - Mouse: Disease Connection (HMDC) and Mammalian Phenotype Ontology."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "マウス研究の総合サイトです。マウス遺伝子に関する情報の他、遺伝子発現データ、多型・変異情報、パスウエイ、遺伝性癌症候群モデルラットに関するデータ、マウス各系統の表現型に関する詳細な情報等を提供しています。Mammalian Phenotype Ontology を作成管理しており、 オントロジーの検索・閲覧もできます(http://www.informatics.jax.org/vocab/mp_ontology) 。Human - Mouse: Disease Connection (HMDC) により、ヒトとマウスの遺伝子や表現型を統合して検索ができます。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "MGI"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "The Jackson Laboratory"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "The Jackson Laboratory"
-                      }
-                    }
-                  },
-                  "mirbase": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "miRBase is a database for published microRNA sequences and annotations, which include mature miRNA sequences (indicated by miR), and hairpin structures predicted by sequences that are precursors for miRNA (indicated by mir). A variety of search methods can be used, including by keyword, genomic position, cluster, expression data, and user-provided sequences. Furthermore, these sequences and annotations can be downloaded."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "公開されているmicroRNAの配列について、配列から予測されるmiRNA前駆体のヘアピン構造(mirで示されます)、成熟miRNAの配列(miRで示されます)、文献情報等が登録されています。様々な検索機能が用意されており、キーワード検索、ゲノム位置による検索、クラスター検索、発現実験による検索、ユーザ自身の配列による検索が行えます。全ての配列とアノテーションはダウンロード可能です。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "miRBase"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "Faculty of Life Sciences(The University of Manchester)"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "Faculty of Life Sciences (The University of Manchester)"
-                      }
-                    }
-                  },
-                  "mondo": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "Mondo is an ontology for integrating disease definitions. It collects disease definitions and data models from numerous sources, which include HPO, OMIM, SNOMED CT, ICD, PhenoDB, MedDRA, MedGen, ORDO, DO, GARD, etc. It provides a hierarchical structure which can be used for classification or \"rolling up\" diseases to higher level groupings."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "疾病の定義を統合して構築したオントロジーです。疾病を定義しデータモデルを収録している多くのデータベース（HPO、OMIM、SNOMED CT、ICD、PhenoDB、MedDRA、MedGen、ORDO、DO、GARDなど）から情報を収集しています。開発当初は半自動で構築されていましたが、広範囲に渡り手動でキュレーションされるようになってきています。疾病の個々の症状、特徴の説明はHPOに準拠しており、疾病は階層構造で表示できます。OWL形式を利用したmondo-with-equivalent、obo、jsonの３つのフォーマットで利用可能です。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "MONDO"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "Monarch Initiative"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "Monarch Initiative"
-                      }
-                    }
-                  },
-                  "nando": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "NanbyoData provides informative data related to intractable diseases using Nanbyo Disease Ontology (NANDO). Designated intractable diseases and chronic specific pediatric diseases in Japan are the subject diseases. NANDO, and genes and phenotypes related intractable diseases are downloadable."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "NanbyoDataは難病オントロジー（Nanbyo Disease Ontology, NANDO）を介して国内外の難病関連情報を集積したサイトです。日本の難病関連制度である指定難病・小児慢性特定疾病の対象疾患に関して詳細な分類までを網羅し、その概要（日英）とOMIM、Orphanet、MedGen、Monarch Initiative、KEGG Diseaseへのリンク情報を提供しています。NANDOはサイトからダウンロードして利用できる他、語彙一覧 (http://nanbyodata.jp/ontology/nando) と階層構造 (http://bioportal.bioontology.org/ontologies/NANDO/?p=classes&conceptid=root) がweb上から参照できます。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "NanbyoData"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "Research Organization of Information and Systems Database Center for Life Science"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "情報・システム研究機構　ライフサイエンス統合データベースセンター"
-                      }
-                    }
-                  },
-                  "ncbigene": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "The gene database provides information on gene sequence, structure, location, and function for annotated genes from the NCBI database. Users can search by accession ID or keyword, compare and identify sequences using BLAST, or submit references into function (RIFs) based on experimental results. Bulk download and an update mailing list are available."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "生物種別の遺伝子単位でエントリーを構成しており、NCBIの様々なデータベースを統合的に利用して遺伝子情報を掲載しています。染色体上の位置、配列、発現、構造、機能、ホモロジーデータのような遺伝子をベースとした情報を提供しています。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "NCBI Gene"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      }
-                    }
-                  },
-                  "ncbiprotein": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "NCBI is a portal site for US biological study data. The site contains links to several NIH research resources, most of which are repositories for submission of data from government-funded and/or published projects. Users can search the entire NCBI collection or perform keyword searches of a specific database from the NCBI search bar. Constituent databases contain a wealth of data for download."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "NCBI（米国立バイオテクノロジー情報センター）は、NIH（米国立衛生研究所）のNLM（米国立医学図書館）の一部門として1988年に設立されたバイオインフォマティクス研究組織です。1989年にBLAST、1990年に検索システムEntrezを開発しました。現在では、NCBI内の各種データベースに対する検索を統一的なインタフェースで行えるようにしています。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "NCBI"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      }
-                    }
-                  },
-                  "oma_group": {
-                    "type": "object"
-                  },
-                  "oma_protein": {
-                    "type": "object"
-                  },
-                  "omim_gene": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "OMIM is a database of human disease and genetic information and the online representation of Mendelian Inheritance in Man, a project initiated in the 1960s. The database summarizes heritable traits and provides information on both the trait and experimentally determined genetic causes. The database is manually curated by experts and can be searched by OMIM ID, gene, disease, or phenotype."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "Johns Hopkins大学のVictor A. McKusick 博士が中心となって記述、編集を行っている、ヒトの遺伝子変異と遺伝病のデータベースです。全ての既知のメンデル型遺伝病と12,000以上の遺伝子に関して、テキスト形式の情報やリファレンスが示されます。MEDLINEやEntrezのリンクも含まれます。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "OMIM"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      }
-                    }
-                  },
-                  "omim_phenotype": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "OMIM is a database of human disease and genetic information and the online representation of Mendelian Inheritance in Man, a project initiated in the 1960s. The database summarizes heritable traits and provides information on both the trait and experimentally determined genetic causes. The database is manually curated by experts and can be searched by OMIM ID, gene, disease, or phenotype."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "Johns Hopkins大学のVictor A. McKusick 博士が中心となって記述、編集を行っている、ヒトの遺伝子変異と遺伝病のデータベースです。全ての既知のメンデル型遺伝病と12,000以上の遺伝子に関して、テキスト形式の情報やリファレンスが示されます。MEDLINEやEntrezのリンクも含まれます。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "OMIM"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      }
-                    }
-                  },
-                  "orphanet": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "Orphanet is a portal site for rare diseases and orphan drugs. It provides inventory of rare diseases and classification, inventory of orphan drugs, clinical trials, etc."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "Orphanetは希少疾患患者の診断と治療の向上を図ることを目的とした、希少疾患や希少疾患用医薬品について様々な情報を参照可能にしたデータベースです。疾患や薬に関する一般的な情報をはじめとして、臨床試験情報、関連する論文や、有病率、発症歴、症状、地域情報などを検索可能です。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "Orphanet"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "Orphanet"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "フランス国立保健医学研究所"
-                      }
-                    }
-                  },
-                  "pdb": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "This is an international public repository for three-dimensional structures and structure coordinates (conformations) of proteins and nucleic acids, and the central database for biological structural data. Data obtained through X-ray crystallography and NMR experiments are stored in PDB. In addition to three-dimensional information of proteins, users can find amino acid sequences, protein-related information on GO, and other compounds bound to the protein."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "タンパク質と核酸の３次元構造の構造座標（立体配座）を蓄積している国際的な公共レポジトリです。\n　RCSB PDB （https://integbio.jp/dbcatalog/record/nbdc01865 ）\n　PDBe （https://integbio.jp/dbcatalog/record/nbdc00613 ）\n　PDBj （https://integbio.jp/dbcatalog/record/nbdc00157 ）\n　BMRB （https://integbio.jp/dbcatalog/record/nbdc00380 ）\n上記４つデータベースの集合体として、X線結晶構造解析やNMRなどで実験的に決定されたタンパク質の立体構造データの他に、アミノ酸配列、GOといったタンパク質に関する情報やタンパク質に結合している化合物の情報を統合し提供しています。検証データ登録のためのツールや登録データのダウンロードが可能なFTPサイトを装備しています。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "wwPDB"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "wwPDB consortium"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "wwPDB consortium"
-                      }
-                    }
-                  },
-                  "pfam": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "Pfam Version 26.0 is a comprehensive database of protein families containing multiple sequence alignments and HMMs.\nThis repository provides data on 13,672 protein families.\nThe site can be searched with a known protein sequence for matching families. \nOptions to search for a Pfam family, clan, sequence or structure are available.\nA keyword search option is also provided."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "現在最もよく整備されたタンパク質ドメインデータベースの一つで、膨大な数のタンパク質ファミリーのコレクションを保持しています。手作業で分類を行った高品質のPfam-Aと、機械的に分類を行ったPfam-Bから構成されています。最大の特徴は、検索システムとしてHMMERというプログラムを使用している点であり、これにより高速で精度の高いモチーフの検索を可能にしています。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "Pfam"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "EMBL-EBI"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "EMBL-EBI"
-                      }
-                    }
-                  },
-                  "pubchem_compound": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "PubChem Compound is a database of chemical structrues of validated small molecules. The dataase contains entries for PubChem entities which are grouped by structural identity and similarity. Users can submit compounds and download via FTP."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "化合物名や分子量、CompoundIDなどで化合物の情報を検索することができるサイトです。医薬品名やその効能、LogP値などの物性値も掲載されています。また、類似構造を持つ別の化合物の検索も可能です。PubChem Substanceが一つの化合物に対して異なる情報をもつ複数のエントリをもつ可能性があるのに対し、PubChem CompoundはPubChem Substanceで得られた種々の情報を一つのエントリに集約して提供しています。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "PubChem Compound"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      }
-                    }
-                  },
-                  "pubchem_substance": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "PubChem Substance is a database of samples of chemical entities which links to the biological activity of those samples in PubChem BioAssay. The database contains structural information on substances with links to further information in cases where the substance has been more fully characterized. It consists of records of chemical entities deposited by various contributors, so a chemical entity may be described different records with different data in this database."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "PubChem Substanceは、出版社、研究者、化学ベンダー、製薬会社、および多くの重要なケミカルバイオロジーリソースをもつ研究者によって提供された化学物質とその生物活性に関する情報のオープンアーカイブです。特定の化学物質に関して個々の提供者からの情報が含まれており、１つの化合物に対して提供者が異なる別のレコードとして異なる情報を提供している可能性があります。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "PubChem Substance"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      }
-                    }
-                  },
-                  "pubmed": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "This database contains bibliographic information from journal articles in the field of life science as well as MEDLINE (title, authors, journal name, abstracts). Links are provided for articles with free access to the full article."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "MEDLINEおよび生命科学分野のジャーナル文献の書誌情報（タイトル、著者名、雑誌名、抄録など）を収録したデータベースです。全文をフリーで公開している文献については、提供サイトへのリンクが張られています。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "PubMed"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      }
-                    }
-                  },
-                  "reactome_pathway": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "REACTOME is a database of human pathways for basic research, genome analysis, pathway modeling, systems biology and education. It contains manually curated and peer-reviewed pathway data which are annotated by expert biologists, in collaboration with Reactome editorial staff and cross-referenced to many bioinformatics databases. This database provides an intuitive website to navigate pathway knowledge and a suite of data analysis tools to support the pathway-based analysis of complex experimental and computational data sets. The curated  human pathway data are available to infer orthologous events in 20 non-human species including mouse, rat, chicken, worm, fly, yeast, plant and bacteria. Using species comparison tool, users are able to compare predicted pathways with those of human to find reactions and pathways common to a selected species and human."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "ヒトの生体内の主要反応経路や生化学反応を整備したデータベースです。ヒト以外の20生物種のデータも格納しており、ヒトとの比較ができます。ここに収録されている情報は、それぞれの分野の専門家が編集しているため、非常に信頼性の高いデータベースです。代謝パスウェイ、シグナル伝達や膜輸送、感染など様々なパスウェイが扱われており、SBGN (Sytem Biology Graphical Notation)形式で視覚化されています。パスウエイ解析、生物種間比較、発現解析も行えます。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "REACTOME"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "Reactome team"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "Reactome Team"
-                      }
-                    }
-                  },
-                  "reactome_reaction": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "REACTOME is a database of human pathways for basic research, genome analysis, pathway modeling, systems biology and education. It contains manually curated and peer-reviewed pathway data which are annotated by expert biologists, in collaboration with Reactome editorial staff and cross-referenced to many bioinformatics databases. This database provides an intuitive website to navigate pathway knowledge and a suite of data analysis tools to support the pathway-based analysis of complex experimental and computational data sets. The curated  human pathway data are available to infer orthologous events in 20 non-human species including mouse, rat, chicken, worm, fly, yeast, plant and bacteria. Using species comparison tool, users are able to compare predicted pathways with those of human to find reactions and pathways common to a selected species and human."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "ヒトの生体内の主要反応経路や生化学反応を整備したデータベースです。ヒト以外の20生物種のデータも格納しており、ヒトとの比較ができます。ここに収録されている情報は、それぞれの分野の専門家が編集しているため、非常に信頼性の高いデータベースです。代謝パスウェイ、シグナル伝達や膜輸送、感染など様々なパスウェイが扱われており、SBGN (Sytem Biology Graphical Notation)形式で視覚化されています。パスウエイ解析、生物種間比較、発現解析も行えます。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "REACTOME"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "Reactome team"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "Reactome Team"
-                      }
-                    }
-                  },
-                  "refseq_genomic": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "RefSeq is a database of standard reference genomic, transcript, and protein sequences. The database contains consensus sequence data for over 20,000 organisms and over 27 million proteins and is designed to provide a common basis for experimental studies that can be searched using accession ID, keyword, or BLAST. Bulk data is available for FTP download."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "異なる生物種由来の冗長性を排除したDNA, RNA, タンパク配列を収録したデータベースです。プラスミド、オルガネラ、ウイルス、古細菌、真正細菌、真核生物のアノテーション付けされた配列が含まれています。生物種ごとに、標準となる配列の包括的データセットを提供することを目的としています。配列の情報源はGenBank由来ですが、それらの中から情報を統合して標準となる配列を提供しています。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "RefSeq"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      }
-                    }
-                  },
-                  "refseq_protein": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "RefSeq is a database of standard reference genomic, transcript, and protein sequences. The database contains consensus sequence data for over 20,000 organisms and over 27 million proteins and is designed to provide a common basis for experimental studies that can be searched using accession ID, keyword, or BLAST. Bulk data is available for FTP download."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "異なる生物種由来の冗長性を排除したDNA, RNA, タンパク配列を収録したデータベースです。プラスミド、オルガネラ、ウイルス、古細菌、真正細菌、真核生物のアノテーション付けされた配列が含まれています。生物種ごとに、標準となる配列の包括的データセットを提供することを目的としています。配列の情報源はGenBank由来ですが、それらの中から情報を統合して標準となる配列を提供しています。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "RefSeq"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      }
-                    }
-                  },
-                  "refseq_rna": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "RefSeq is a database of standard reference genomic, transcript, and protein sequences. The database contains consensus sequence data for over 20,000 organisms and over 27 million proteins and is designed to provide a common basis for experimental studies that can be searched using accession ID, keyword, or BLAST. Bulk data is available for FTP download."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "異なる生物種由来の冗長性を排除したDNA, RNA, タンパク配列を収録したデータベースです。プラスミド、オルガネラ、ウイルス、古細菌、真正細菌、真核生物のアノテーション付けされた配列が含まれています。生物種ごとに、標準となる配列の包括的データセットを提供することを目的としています。配列の情報源はGenBank由来ですが、それらの中から情報を統合して標準となる配列を提供しています。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "RefSeq"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      }
-                    }
-                  },
-                  "rgd": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "This is a comprehensive site for rat genome researches. In addition to information on rat genes, the site contains information on rat strains, data on rat models for disease, and publications."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "ラットゲノム研究の総合サイトです。ラット遺伝子に関する情報の他に、ラットの系統に関する情報、病態モデルラットに関するデータ、文献情報等を提供しています。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "RGD"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "Medical College of Wisconsin/Bioinformatics Research Center"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "Medical College of Wisconsin/Bioinformatics Research Center"
-                      }
-                    }
-                  },
-                  "rhea": {
-                    "type": "object"
-                  },
-                  "sra_accession": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "SRA is a database of raw sequence reads from next-generation sequencing systems. The database contains millions of unannotated raw reads generated from a variety of projects. Data can be submitted to the archive or downloaded via FTP."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "次世代シーケンサーによる配列データのレポジトリサイトです。現在扱っているプラットフォームは454(ロシュ)、Genome Analyzer(イルミナ)、SOLiD(アプライドバイオシステムズ)、Heliscope(ヘリコス)。研究単位でデータの登録、配布を行っています。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "SRA"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      }
-                    }
-                  },
-                  "sra_analysis": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "SRA is a database of raw sequence reads from next-generation sequencing systems. The database contains millions of unannotated raw reads generated from a variety of projects. Data can be submitted to the archive or downloaded via FTP."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "次世代シーケンサーによる配列データのレポジトリサイトです。現在扱っているプラットフォームは454(ロシュ)、Genome Analyzer(イルミナ)、SOLiD(アプライドバイオシステムズ)、Heliscope(ヘリコス)。研究単位でデータの登録、配布を行っています。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "SRA"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      }
-                    }
-                  },
-                  "sra_experiment": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "SRA is a database of raw sequence reads from next-generation sequencing systems. The database contains millions of unannotated raw reads generated from a variety of projects. Data can be submitted to the archive or downloaded via FTP."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "次世代シーケンサーによる配列データのレポジトリサイトです。現在扱っているプラットフォームは454(ロシュ)、Genome Analyzer(イルミナ)、SOLiD(アプライドバイオシステムズ)、Heliscope(ヘリコス)。研究単位でデータの登録、配布を行っています。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "SRA"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      }
-                    }
-                  },
-                  "sra_project": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "SRA is a database of raw sequence reads from next-generation sequencing systems. The database contains millions of unannotated raw reads generated from a variety of projects. Data can be submitted to the archive or downloaded via FTP."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "次世代シーケンサーによる配列データのレポジトリサイトです。現在扱っているプラットフォームは454(ロシュ)、Genome Analyzer(イルミナ)、SOLiD(アプライドバイオシステムズ)、Heliscope(ヘリコス)。研究単位でデータの登録、配布を行っています。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "SRA"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      }
-                    }
-                  },
-                  "sra_run": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "SRA is a database of raw sequence reads from next-generation sequencing systems. The database contains millions of unannotated raw reads generated from a variety of projects. Data can be submitted to the archive or downloaded via FTP."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "次世代シーケンサーによる配列データのレポジトリサイトです。現在扱っているプラットフォームは454(ロシュ)、Genome Analyzer(イルミナ)、SOLiD(アプライドバイオシステムズ)、Heliscope(ヘリコス)。研究単位でデータの登録、配布を行っています。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "SRA"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      }
-                    }
-                  },
-                  "sra_sample": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "SRA is a database of raw sequence reads from next-generation sequencing systems. The database contains millions of unannotated raw reads generated from a variety of projects. Data can be submitted to the archive or downloaded via FTP."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "次世代シーケンサーによる配列データのレポジトリサイトです。現在扱っているプラットフォームは454(ロシュ)、Genome Analyzer(イルミナ)、SOLiD(アプライドバイオシステムズ)、Heliscope(ヘリコス)。研究単位でデータの登録、配布を行っています。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "SRA"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      }
-                    }
-                  },
-                  "taxonomy": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "Taxonomy is a database of systematic classifications of organisms repesented in public sequencing databases. The database contains phylogenetic relatonships and nomenclature for an estimated 10% of all living species. Tools include a browser, genetic codes, and a common evolutionary tree. Taxonomic classificatinos can be downloaded via FTP."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "NCBI Entrezデータベースに少なくとも1件以上登録されている全ての生物種と上位分類名を収集したデータベースです。160,000以上の生物種が登録されています。各エントリーには、学名、英名、階層分類、上位階層、Entrezデータベース群の収録数とリンクが含まれています。このデータベースは、種々のデータベース間で生物名の表記を統一することを目的として構築しており、分類学や系統発生学の権威となるものではありません。採用されている生物名や系統分類は、分類学的、系統発生学的に普及している内容と異なる場合があります。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "Taxonomy - NCBI"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "National Center for Biotechnology Information"
-                      }
-                    }
-                  },
-                  "togovar": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "TogoVar (NBDC's integrated database of Japanese genomic variation) is a database that has collected and organized genome sequence differences between individuals (variants) in the Japanese population and disease information associated with them. TogoVar provides variant frequencies in the Japanese population that have been aggregated across research projects. Two available datasets, JGA-NGS and JGA-SNP, are obtained by aggregating individual genomic data that have been registered in the NBDC Human Database / Japanese Genotype-phenotype Archive (JGA). In addition, TogoVar integrates information related to genotypes or phenotypes that has been compiled independently in a variety of different databases and provides information for interpreting variants in a one-stop, easy-to-understand manner.\nUsers can learn how to use it by a movie: https://togotv.dbcls.jp/en/20181012.html"
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "TogoVar（日本人ゲノム多様性統合データベース）は、日本人ゲノム配列の個人による違い（バリアント）とそれに関係する疾患情報などを収集・整理したデータベースです。TogoVarは、研究プロジェクト横断的に集約した日本人におけるバリアントの頻度情報を提供します。利用可能な２つのデータセットであるJGA-NGSとJGA-SNPはNBDCヒトデータベース/Japanese Genotype-phenotype Archive (JGA)に登録されている個人ごとのゲノムデータを集約して得られた頻度情報です。さらに、多種多様なデータベースに散在して収録されてきた遺伝子型や表現型に関連する情報を整理統合し、バリアントを解釈するための情報をワンストップでわかりやすく提供します。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "TogoVar"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "National Bioscience Database Center"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "国立研究開発法人科学技術振興機構　バイオサイエンスデータベースセンター"
-                      }
-                    }
-                  },
-                  "uniprot": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "This database contains information on amino acid sequences and their functions. It is composed of four core databases, UniProtKB, UniRef, UniParc, and Proteomes. UniProtKB contains two types of data, which are manually curated high quality SwissProt annotations based on literature information, and automatically annotated TrEMBL. \r\nUniRef provides results of sequence similarity searches. \r\nUniParc integrates information such as ID for other databases per sequence ID.\r\nProteomes provides proteome data of each organism with completely sequenced genomes."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "アミノ酸配列とその機能情報を掲載している代表的なデータベースです。「UniProtKB」、「UniRef」、「UniParc」の3種類のデータベースから構成されています。\nUniProtKB: 文献情報などを元に手作業で高品質のアノテーションを付けたSwissProtと、機械的にアノテーションを加えたTrEMBLを公開しています。\nUniRef: あらかじめ行われた配列相同性検索の結果を提供しています。\nUniParc: 配列IDごとに他のデータベースのID等の情報をまとめています。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "UniProt"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "UniProt Consortium"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "UniProt Consortium"
-                      }
-                    }
-                  },
-                  "uniprot_mnemonic": {
-                    "properties": {
-                      "description_en": {
-                        "type": "string",
-                        "example": "This database contains information on amino acid sequences and their functions. It is composed of four core databases, UniProtKB, UniRef, UniParc, and Proteomes. UniProtKB contains two types of data, which are manually curated high quality SwissProt annotations based on literature information, and automatically annotated TrEMBL. \r\nUniRef provides results of sequence similarity searches. \r\nUniParc integrates information such as ID for other databases per sequence ID.\r\nProteomes provides proteome data of each organism with completely sequenced genomes."
-                      },
-                      "description_ja": {
-                        "type": "string",
-                        "example": "アミノ酸配列とその機能情報を掲載している代表的なデータベースです。「UniProtKB」、「UniRef」、「UniParc」の3種類のデータベースから構成されています。\nUniProtKB: 文献情報などを元に手作業で高品質のアノテーションを付けたSwissProtと、機械的にアノテーションを加えたTrEMBLを公開しています。\nUniRef: あらかじめ行われた配列相同性検索の結果を提供しています。\nUniParc: 配列IDごとに他のデータベースのID等の情報をまとめています。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "UniProt"
-                      },
-                      "organization_en": {
-                        "type": "string",
-                        "example": "UniProt Consortium"
-                      },
-                      "organization_ja": {
-                        "type": "string",
-                        "example": "UniProt Consortium"
-                      }
+      }
+    },
+    "/config/descriptions": {
+      "get": {
+        "tags": ["config"],
+        "summary": "Get database description",
+        "operationId": "getDescription",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "bioproject": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "BioProject is a database which collects the results of research projects under the umbrella of the project or initiative. The database consists of tables of projects, which users can search or browse to find all data outputs related to that project. Users can submit projects or download data via FTP."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "特定の組織やコンソーシアムにより立ち上げられたゲノムプロジェクトをはじめとする生命科学分野の各種プロジェクトを単位とし、そこから産生されたデータセットをまとめたデータベースです。産生された配列データに関しては完全決定配列（ドラフト、進行中を含む）、アセンブリ、アノテーション、マッピングなどの進捗状況が含まれています。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "BioProject (Formerly Genome Project)"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        }
+                      }
+                    },
+                    "biosample": {
+                      "type": "object"
+                    },
+                    "ccds": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "This database seeks to identify a core set of human and mouse protein coding regions of high quality that are consistently annotated."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "高品質で確実にアノテーション付けされたヒトとマウスのタンパク質コード領域のコアセットを集約し、提供しているデータベースです。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "CCDS"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        }
+                      }
+                    },
+                    "chebi": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "ChEBI is a collection of data on entities of biological interest.\nThis database concentrates on assembling data on smaller chemical compounds, such as atoms, molecules, ions, radicals etc. These should be produced in nature or be synthetic molecules affecting biological processes in living organisms.\nChEBI does not generally include molecules directly encoded by the genome.\nThe database contains 31,651 entries with annotations.\nA keyword search option is available.\nIn addition to this an advanced search option, which includes a structure drawing tool, is provided.\nThe ChEBI database can be searched individually or in combination with other databases."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "生命プロセスに介在する小分子化合物の辞典です。ゲノムに直接コード化されている分子（例：核酸、タンパク、ペプチド）はこのデータベースの対象外です。登録されているデータは、多数の情報源のデータを組み合わせ、冗長性を除いています。主な情報源はIntEnz(EBI)、KEGG COMPOUND、PDBeChem(EBI)、ChEMBL(EBI)です。 ChEBIオントロジー（化合物オントロジー）による分類情報と階層表示が特徴です。\n全てのエントリーにはデータの信頼性を示す★印がついています； 3つ星：ChEBIチームが手作業で注釈付けを行ったもの。2つ星：ChEMBLチームまたはデータ提供者が手作業で注釈付けを行ったもの。1つ星：情報源から自動的に取得した仮エントリーで、手作業での注釈付けが行われていないもの。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "ChEBI"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "European Bioinformatics Institute"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "European Bioinformatics Institute"
+                        }
+                      }
+                    },
+                    "chembl_compound": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "ChEMBL is a database for bioactive molecules. It collects information of small molecules, such as calculated properties (e.g. logP, Molecular Weight, Lipinski Parameters, etc.) and abstracted bioactivities (e.g. binding constants, pharmacology and ADMET data), and the target information. Metadata of assays for small molecule activities or assays for binding activities between small molecules and its targets are also provided."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "ChEMBLは創薬を目的とした生理活性をもつ化合物や小分子のデータベースです。化合物、核酸などの小分子と、そのターゲットやアッセイ情報を紐付けて収載しています。化合物や小分子の名称、分子式、分子量、標準SMILES、標準InChIなどの情報に加え、結合定数、ADMEデータなど生理活性に関する情報や、薬としての開発段階の情報などが付与されています。化合物を名称や構造で検索したり、ターゲットをタンパク質の名称で検索することができます。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "ChEMBL"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "EMBL-EBI"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "EMBL-EBI"
+                        }
+                      }
+                    },
+                    "chembl_target": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "ChEMBL is a database for bioactive molecules. It collects information of small molecules, such as calculated properties (e.g. logP, Molecular Weight, Lipinski Parameters, etc.) and abstracted bioactivities (e.g. binding constants, pharmacology and ADMET data), and the target information. Metadata of assays for small molecule activities or assays for binding activities between small molecules and its targets are also provided."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "ChEMBLは創薬を目的とした生理活性をもつ化合物や小分子のデータベースです。化合物、核酸などの小分子と、そのターゲットやアッセイ情報を紐付けて収載しています。化合物や小分子の名称、分子式、分子量、標準SMILES、標準InChIなどの情報に加え、結合定数、ADMEデータなど生理活性に関する情報や、薬としての開発段階の情報などが付与されています。化合物を名称や構造で検索したり、ターゲットをタンパク質の名称で検索することができます。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "ChEMBL"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "EMBL-EBI"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "EMBL-EBI"
+                        }
+                      }
+                    },
+                    "civic_gene": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "CIViC is a knowledgebase for Clinical Interpretation of Variants in Cancer. It has collected knowledge of the therapeutic, prognostic, diagnostic and predisposing relevance of inherited and somatic variants in cancer based on expert-crowdsourcing."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "CIViCは癌におけるバリアントの臨床的解釈のための知識ベースです。遺伝性および体細胞性の全てのタイプの癌におけるバリアント情報と、その治療、予後、診断、素因への関連性を、専門家によるクラウドソーシングの形式で収集しています。バリアント、遺伝子、疾患、薬、evidence情報が整理されています。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "CIVIC"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "The McDonnell Genome Institute, Washington University School of Medicine"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "The McDonnell Genome Institute, Washington University School of Medicine"
+                        }
+                      }
+                    },
+                    "clinvar": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "ClinVar is a freely available archive describing relationships between medically important variants and phenotypes. Submissions report human variation, interpretations of the relationship of that variation to human health, and the evidence supporting each interpretation. ClinVar is tightly coupled with dbSNP and dbVar, which maintain information about locations of variations on human assemblies, and also based on the phenotypic descriptions maintained in MedGen (http://www.ncbi.nlm.nih.gov/medgen). Each record contains the submitter, the variation and the phenotype. Furthermore, to facilitate evaluation of the medical importance of each variant, ClinVar aggregates submissions with the same variation/phenotype combination, adds value from other NCBI databases, and reports if there are conflicting clinical interpretations. Data in ClinVar are available in multiple formats, including html, download as XML, VCF or tab-delimited subsets."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "ヒトゲノムの多様性と関連する疾患についての情報を収集し、自由に利用できるアーカイブとして提供しているデータベースです。多型の位置、遺伝子名、疾患との関わりなどを収録しています。遺伝子情報はNCBIのdbSNPおよびdbVarと、表現型に関してはMedGenとリンクしています。また、NIH Genetic Testing Registry (GTR)、OMIM、PubMedからも情報を収集しています。各データはhtml形式での閲覧の他、XMLやタブ区切り形式、一部データはVCFファイルでダウンロードできます。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "ClinVar"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        }
+                      }
+                    },
+                    "dbsnp": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "dbSNP collects information on polymorphisms based on single and small-scale multi-base substitutions, including insertions and deletions, microsatelites, and non-polymorphic variants. Differences in the frequency of polymorphisms in a population can be visually compared for each SNP."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "1～数塩基の置換、挿入/欠失、反復等の多型情報からなるデータベースです。各SNPについて、集団間での多型頻度の違いを視覚的に比較することもできます。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "dbSNP"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        }
+                      }
+                    },
+                    "dgidb": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "DGIdb is a database about drug-gene interactions and the druggable genome. It collects and integrates drug-gene interactions and gene druggability information from papers, databases and web resources, such as DrugBank, PharmGKB, ChEMBL, Drug Target Commons, TTD, and others, using a combination of expert curation and text-mining. It consists of gene records for gene details, drug records for drug details and Interaction records for interaction of the genes and drugs. Users can enter a list of genes to retrieve all known or potentially druggable genes in that list. Results can be filtered by source, interaction type, or gene category."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "DGIdbは薬物と遺伝子の相互作用および創薬可能なゲノム資源に関するデータベースです。 DrugBank、PharmGKB、Chembl、Drug Target Commons、TTDなど、様々な論文、データベース、その他のWebリソースから、薬物と遺伝子の相互作用および遺伝子の創薬への適用可能性情報を専門家によるキュレーションとテキストマイニングにより整理・統合して提供しています。 薬に関するレコード、遺伝子に関するレコード、相互作用に関するレコードに分かれて整理されており、相互に参照できます。すべてのデータは、無料でダウンロードするか（＊ダウンロードページに条件が記載されている場合を除く）、APIを介してアクセスできます。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "DGiDB"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "McDonnell Genome Institute, Washington University School of Medicine"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "McDonnell Genome Institute, Washington University School of Medicine"
+                        }
+                      }
+                    },
+                    "doid": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "This site provides a Disease Ontology, which is a standardized ontology organized by human disease terms and related medical concepts. The DO terms are associated with MeSH, ICD, NCI's thesaurus, SNOMED and OMIM to integrate disease and medical vocabularies."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "ヒトの疾患に関する用語や概念について整理したDisease Ontologyを提供するサイトです。MeSH、ICD、NCI’s thesaurus、SNOMEDやOMIMへリンク付けられています。キーワードで語彙を検索することができます。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "DO"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "Institute of Genome Sciences, University of Maryland School of Medicine"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "Institute of Genome Sciences, University of Maryland School of Medicine"
+                        }
+                      }
+                    },
+                    "drugbank": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "DrugBank is a database of detailed informatics resources on approved and experimental drugs. The database contains informaiton on drug targets as well as the results of experiments resulting in extensive bioinformatics and chemoinformatics data. Users can browse or search by drug or target. Data is available for download."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "薬剤の化学的、薬理的、薬事的データとそのターゲット（配列、構造、パスウエイ）の詳細情報を収集、統合したバイオインフォマティクスおよびケモインフォマティクスのリソースです。薬剤エントリー約4,800件のうち、FDA承認小分子薬剤が1,350以上、FDA承認バイオテク（タンパク/ペプチド）薬剤123件、栄養補助食品71件、実験的薬剤が3,243件以上が含まれています。2,500以上の非冗長タンパク配列がFDA承認薬剤エントリーにリンクしています。各エントリーにつき100以上のデータ項目が存在します。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "DrugBank"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "University of Alberta/Department of Computing Science"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "University of Alberta/Department of Computing Science"
+                        }
+                      }
+                    },
+                    "ec": {
+                      "type": "object"
+                    },
+                    "ena": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "ENA is a database of data from global nucleotide sequencing projects. The database contains information on projects from raw phases trhough complete functional annotation. Users can search by keyword or DNA sequence. Bulk data is available for download."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "次世代シーケンサーによる配列データのレポジトリサイトです。サンプル、実験情報、機器情報、データとしては配列トレース、配列、クオリティ値を含み、アセンブル、マッピング、機能アノテーションも提供しています。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "ENA"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "European Bioinformatics Institute"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "European Bioinformatics Institute"
+                        }
+                      }
+                    },
+                    "ensembl_gene": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "ENSEMBL is a collection of automatically annotated genome databases for vertebrates and a number of eukaryotes, integrated with all other relevant biological data available.\r\nThe repository covers data on gene annotation, microarray probeset mapping and comparative genomics among many other topics.\r\nInformation may be downloaded by a variety of means: \r\nFor small amounts of data, an export option is suggested.\r\nFor larger amounts of data, an FTP site is provided from where a complete database may be downloaded in one of various formats, from flat files to MySQL dumps."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "ゲノム解読された脊椎生物およびその他の主要な真核生物を対象として自動アノテーションを行い、その結果をゲノムビューワやデータベースとして公開しているプロジェクトです。EMBL-EBIとSanger Centreが共同で進めています。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "Ensembl"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "Wellcome Trust Sanger Institute"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "Wellcome Trust Sanger Institute"
+                        }
+                      }
+                    },
+                    "ensembl_protein": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "ENSEMBL is a collection of automatically annotated genome databases for vertebrates and a number of eukaryotes, integrated with all other relevant biological data available.\r\nThe repository covers data on gene annotation, microarray probeset mapping and comparative genomics among many other topics.\r\nInformation may be downloaded by a variety of means: \r\nFor small amounts of data, an export option is suggested.\r\nFor larger amounts of data, an FTP site is provided from where a complete database may be downloaded in one of various formats, from flat files to MySQL dumps."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "ゲノム解読された脊椎生物およびその他の主要な真核生物を対象として自動アノテーションを行い、その結果をゲノムビューワやデータベースとして公開しているプロジェクトです。EMBL-EBIとSanger Centreが共同で進めています。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "Ensembl"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "Wellcome Trust Sanger Institute"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "Wellcome Trust Sanger Institute"
+                        }
+                      }
+                    },
+                    "ensembl_transcript": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "ENSEMBL is a collection of automatically annotated genome databases for vertebrates and a number of eukaryotes, integrated with all other relevant biological data available.\r\nThe repository covers data on gene annotation, microarray probeset mapping and comparative genomics among many other topics.\r\nInformation may be downloaded by a variety of means: \r\nFor small amounts of data, an export option is suggested.\r\nFor larger amounts of data, an FTP site is provided from where a complete database may be downloaded in one of various formats, from flat files to MySQL dumps."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "ゲノム解読された脊椎生物およびその他の主要な真核生物を対象として自動アノテーションを行い、その結果をゲノムビューワやデータベースとして公開しているプロジェクトです。EMBL-EBIとSanger Centreが共同で進めています。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "Ensembl"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "Wellcome Trust Sanger Institute"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "Wellcome Trust Sanger Institute"
+                        }
+                      }
+                    },
+                    "glytoucan": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "GlyTouCan is an international repository of glycan structures. This database contains uncurated glycan structures ranging in resolution from monosaccharide composition to fully defined structures, as long as there are no inconsistencies in the structure. The database allows users to search by text, graphic input or motif, and browse using motif-list or glycan-list."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "糖鎖構造データを収録した国際糖鎖構造リポジトリです。単糖類組成からグリコシド結合形状などの明確な構造まで、構造に不一致がない限り世界的にユニークなアクセッション番号を付けて登録することができます。キーワード、モチーフ、糖鎖構造画像からの検索、モチーフや糖鎖のリストからのブラウズが可能です。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "GlyTouCan"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "GlyTouCan Project Team"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "GlyTouCan Project Team"
+                        }
+                      }
+                    },
+                    "go": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "GO is a database which provides a controlled vocabulary of terms for describing gene product characteristics and gene product annotation data. It contains data of terms, definitions and ontology structure. The most recent version of the ontology and the annotation files contributed by members of the GO Consortium are available for download. The GO provides the AmiGO browser and search engine which are web browser-based access to the GO database."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "遺伝子オントロジー（Gene Ontology;GO）とは、生物学的概念を記述するための標準となる語彙を策定しようとするプロジェクトです。GOで定義された用語はGO Termと呼ばれ、Cellular component、Biological process、Molecular functionという3つのカテゴリーに分類されています。GOのデータは、非循環有向グラフ (Directed Acyclic Graph: DAG) と呼ばれるデータ構造を用いて計算機上で記述することができます。\nこのサイトでは、GO Termや関連ツールの配布を行っています。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "GO"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "The GO Consortium"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "The GO Consortium"
+                        }
+                      }
+                    },
+                    "hgnc": {
+                      "type": "object"
+                    },
+                    "hgnc_symbol": {
+                      "type": "object"
+                    },
+                    "hmdb": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "HUMDB is a database of human metabolites. The database contains information on thousands of metabolites produced by and found in the human body as a result of metabolic processes. genes and proteins related to the metabolites are also affiliated with records, where appropriate. Data on metabolites and the associated genes and proteins are available for download."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "ヒト体内における低分子代謝物の詳細情報を収集したデータベースです。メタボロミクスや臨床化学、バイオマーカー探索、教育分野で活用されることを目的に構築しており、化学データ、臨床データ、分子生物学/化学データを含んでいます。現在、7,900代謝物が登録されており、7,200のタンパク質（DNA）配列のリンク情報があります。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "HMDB"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "University of Alberta"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "University of Alberta"
+                        }
+                      }
+                    },
+                    "homologene": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "In Homologenes, users can find automatically constructed homologous gene sets from the full-length genome sequences of a wide range of eukaryotic species, as well as mRNA and protein sequences."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "全ゲノム配列が決定された20種類の真核生物の間で自動的検出したホモログ遺伝子のセット、およびmRNAやタンパク質の配列データを提供しています。他の生物種のUniGene配列でホモログの可能性があるものも表示されます。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "HomoloGene"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        }
+                      }
+                    },
+                    "hp": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "The Human Phenotype Ontology (HPO) provides a standardized vocabulary of phenotype specialized in human disease. The medical literatures, Orphanet, DECIPHER, and OMIM are used for developing the HPO."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "The Human Phenotype Ontology (HPO) はヒトの疾患に関連する形質の標準化された語彙を提供しています。医学論文、Orphanet、DECIPHER,やOMIMを基に開発されており、疾患と関連する形質の語彙や、疾患に関連する遺伝子情報が収載されています。疾患名、形質、遺伝子名で検索することができます。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "HPO"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "The Jackson Laboratory"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "The Jackson Laboratory"
+                        }
+                      }
+                    },
+                    "human_protein_atlas": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "Human Protein Atlas is a database of protein expression and localization. The database contains information on where proteins localize within cells and lists antibodies for the detection of human proteins. Information on expression in cancer lines as well as RNA transcript expression is also represented. Elements can be searched by several positional characteristics."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "様々な種類のヒトの器官、組織、細胞におけるタンパク質の発現および局在に関するデータベースです。蛍光抗体イメージング、質量分析に基づくプロテオミクス、網羅的な遺伝子発現解析によるトランスクリプトミクスおよびシステム生物学の手法により得られた情報を遺伝子ごとに記載しています。各レコードは３つのアトラスで構成されています。\n「組織アトラス」：ヒトの主要組織や器官におけるRNA発現量、タンパク質発現量\n「細胞アトラス」：RNA発現量や発現画像、GFP発現画像など細胞内での局在\n「疾病アトラス」：生存がん患者の組織における量的発現解析（RNA-seq）や空間的発現解析（マイクロアレイ）によるタンパク質発現レベル\nまた、抗体の情報、細胞内器官の説明、各組織における腫瘍の説明や生存率の情報なども収録しています。\n遺伝子名、抗体名、タンパク質の分類によるデータの絞り込みが可能です。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "Human Protein Atlas"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "Uppsala University"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "Uppsala University"
+                        }
+                      }
+                    },
+                    "inchi_key": {
+                      "type": "object"
+                    },
+                    "insdc": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "It is a portal site for the INSDC(International Nucleotide Sequence Database Collaboration), which is an initiative operated between DDBJ, EMBL-EBI and NCBI.  Each organization operates DNA databases in close coordination and cooperation with each other to achieve common accession numbers, and standardize data format (INSD-XML). The databases are called the International Nucleotide Sequence Databases (INSD)."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "本サイトは、３大DNAデータベースであるDDBJ、ENA(European Nucleotide Archive)、 NCBIの協力で運営されるINSDC(International Nucleotide Sequence Database Collaboration)のポータルサイトです。INSDCは連携して塩基配列のアクセションIDの共通化やデータ形式の統一(INSD-XML)などに取り組みながら、個々の拠点におけるWebサービスの開発が行われています。INSDCが連携して構築・運営しているデータベースは国際塩基配列データベース (International Nucleotide Sequence Databases, INSD) と呼ばれます。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "INSDC"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "European Bioinformatics Institute (EMBL-EBI)"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "European Bioinformatics Institute (EMBL-EBI)"
+                        }
+                      }
+                    },
+                    "intact": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "IntAct is a database of molecular interactions. The database contains information on more than 400,000 interactions gathered from primary literature. Users can search by gene, protein, or publication, among others, and the database includes manually annotated data from several other interaction databases. Software and bulk data, updoated weekly, are also available for download."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "IntActはオープンソースの分子間相互作用のデータベースとツールキットで構成されています。データは文献から取得したり、専門家によって蓄積されたデータから構成されています。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "IntAct"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "European Bioinformatics Institute"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "European Bioinformatics Institute"
+                        }
+                      }
+                    },
+                    "interpro": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "InterPro is a database that analyses proteins functionally and classifies them into families as well as predicts their domain and sites in the genome.\nThis repository harvests its content from a large number of related databases and consolidates its findings into a single searchable resource avoiding the occurrence of redundant entries.\nInterPro aims to update their content every 8 weeks.\nA keyword search is available and an option is provided where a protein sequence can be entered for analysis."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "EBI によるタンパク質のファミリー分類、ドメイン、機能サイトに関する記述を収集した統合データベースです。UniProtやPROSITE、PANTHER、ProDom、SMARTなどタンパク質の特性を収録している複数のデータベースを集結し、様々なレベルでのタンパク質の特徴を提供しています。InterProScanを用いて、ユーザが入力した配列から機能ドメインや構造ドメインを検索することができます。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "InterPro"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "European Bioinformatics Institute"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "European Bioinformatics Institute"
+                        }
+                      }
+                    },
+                    "kegg_compound": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "KEGG COMPOUND is a database of biologically relevant compounds, including chemical structures and associated information for compounds in the KEGG database such as small molecules, biopolymers, and other related substances. The site also has a collection of links to other relevant KEGG resources such as GLYCAN."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "KEGG COMPOUNDは、小分子、生体高分子、および生体関連化学物質のデータベースです。 各エントリーはC番号とよばれるアクセッション番号で識別され、化学構造や関連する生体反応、パスウエイ、他のデータベースとのリンク情報が含まれています。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "KEGG COMPOUND"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "Kyoto University Institute for Chemical Research Bioinformatics Center"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "京都大学　化学研究所　附属バイオインフォマティクスセンター"
+                        }
+                      }
+                    },
+                    "kegg_disease": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "KEGG DISEASE is a database of human diseases with information on perturbed molecular networks. Each disease entry contains a list of known disease genes, environmental factors (carcinogens, pathogens, etc), diagnostic markers and therapeutic drugs with reference information. This database provides maps of molecular networks associated with diseases through links to the KEGG PATHWAY database. Users can search human diseases by names, description, categories, pathways, and known causative genes."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "KEGG DISEASEは、遺伝要因が既知の疾患（単一遺伝子疾患及び多因子性疾患）と病原体ゲノムが既知の感染症疾患に関する情報を、計算処理が可能な形に集約したデータベースです。各疾患エントリは H番号とよばれるアクセッション番号で識別され、関連するパスウエイ、病因遺伝子のリスト、ならびに環境要因、診断マーカー、治療薬などの分子のリストで表現されています。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "KEGG DISEASE"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "Kyoto University Institute for Chemical Research Bioinformatics Center"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "京都大学　化学研究所　附属バイオインフォマティクスセンター"
+                        }
+                      }
+                    },
+                    "kegg_drug": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "KEGG DRUG is a comprehensive database of drug information about all marketed drugs in Japan, as well as many prescription drugs in USA and Europe. KEGG DRUG is based on chemical structure or component, and each entry contains information about drug targets (pathways), metabolizing enzymes and other interacting molecules. This database also includes crude drugs and TCM (Tradictional Chinese Medicine). Users can check for drug-drug interaction, view structure maps representing the history of drug development and search drugs by generic names, trade names, and components."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "KEGG DRUG は、日本、米国、欧州の医薬品情報を、化学構造と成分の観点から一元的に集約・管理したデータベースです。とくに日本の医薬品は医療用（処方薬）だけでなく一般用（大衆薬、OTC薬）もすべて網羅し、個々の製品情報（添付文書情報）へのリンクがつけられています。また化学薬品だけでなく、生薬・漢方方剤もデータベース化されています。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "KEGG DRUG"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "Kyoto University Institute for Chemical Research Bioinformatics Center"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "京都大学　化学研究所　附属バイオインフォマティクスセンター"
+                        }
+                      }
+                    },
+                    "kegg_genes": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "KEGG geneS is a catalog of gene information for multiple species with species-specified gene information for all species with complete genome sequences. The database references primary sources and provides pathway, ortholog, paralog, and motif searching functions. Results of gene searches include nucleotide and protein information."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "KEGG GENESは、全ゲノム配列が決定された生物種について、その遺伝子セットをRefSeq その他の公共データベースから自動生成し、KEGG 独自のアノテーション（KO アノテーション）を行っているデータベースです。\n以前、VGENES (http://integbio.jp/dbcatalog/record/nbdc00820) や VGENOME (http://integbio.jp/dbcatalog/record/nbdc00821) に収録されていたウィルスに関する情報も収録されています。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "KEGG GENES Database"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "Kyoto University Institute for Chemical Research Bioinformatics Center"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "京都大学　化学研究所　附属バイオインフォマティクスセンター"
+                        }
+                      }
+                    },
+                    "kegg_orthology": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "KEGG ORTHOLOGY is a database of KEGG pathway ortholog groups, and contains the pathways at the core of the KEGG representation system. Users can search for ortholog groups and explore members across species."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "KEGG ORTHOLOGYは、KEGGパスウェイの各ノードまたはBRITE機能階層の最下層ノードに対応したオーソロググループを手作業で定義したものです。ゲノム中の各遺伝子にKO識別子（K番号）を付与することで、KEGGパスウェイやBRITE機能階層へのマッピング（エンリッチメント）が可能となります。KOシステムは、ゲノムの情報からパスウェイ等高次生命システム情報を解読するための架け橋となります。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "KEGG ORTHOLOGY (KO) Database"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "Kyoto University Institute for Chemical Research Bioinformatics Center"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "京都大学　化学研究所　附属バイオインフォマティクスセンター"
+                        }
+                      }
+                    },
+                    "kegg_pathway": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "The KEGG PATHWAY database has manually drawn pathway maps that represent molecular interaction and reaction networks for the following: Global Map, Metabolism, genetic Information Processing, Cellular Processes, Organismal Systems, Human Diseases and also structure relationships in Drug Development. By using KEGG PATHWAY mapping, molecular datasets can be mapped for the biological interpretation of higher-level systemic functions."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "代謝、様々な細胞プロセス、ヒト疾患などに関する分子ネットワークの知識を表現したパスウェイマップを収録しています。マップは文献等から手作業で作成しています。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "KEGG PATHWAY Database"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "Kyoto University Institute for Chemical Research Bioinformatics Center"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "京都大学　化学研究所　附属バイオインフォマティクスセンター"
+                        }
+                      }
+                    },
+                    "kegg_reaction": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "KEGG REACTION is a database of enzymatic reactions. The database contains all KEGG enzyme interactions and KEGG pathway metabolic reactions, including related pathways, and uses IUBMB nomenclature. Users can also find the reaction pathway of individual enzymes."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "KEGG REACTIONは、KEGG ENZYMEに格納されているすべての反応と、KEGG PATHWAYの代謝パスウエイの反応を蓄積したデータベースです。 各反応はR番号によって識別され、 反応の構造式や関連する酵素のオーソロググループが収集されており、ゲノム(酵素遺伝子)情報と化学(化合物のペア)情報の統合解析を可能としています。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "KEGG REACTION"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "Kyoto University Institute for Chemical Research Bioinformatics Center"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "京都大学　化学研究所　附属バイオインフォマティクスセンター"
+                        }
+                      }
+                    },
+                    "lrg": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "LRG is a database of stable genomic, transcript and protein reference sequences for reporting clinically relevant sequence variants. NCBI (RefSeq) and EMBL-EBI (Ensembl/GENCODE) are working together to rationalise differences in their gene sets. Records contain information about genomic, transcript and protein sequences, annotations, maps about the genome assembly, etc. This database allows users to search using LRG identifier, HGNC gene name, NCBI and Ensembl accession numbers (gene or transcript), gene synonym or LRG status (public or pending). Genome browsers on Ensembl, NCBI and UCSC are available."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "ゲノム、転写産物、タンパク質のリファレンス配列のデータベースです。臨床に関連する変異配列を報告するためのリファレンス配列を、 NCBI（RefSeq）とEMBL-EBI（Ensembl / GENCODE）の協力により情報統合しています。 各レコードには、ゲノム、転写産物、タンパク質の配列、アノテーション、ゲノムアセンブリに関するマップなどが含まれています。LRG番号、HGNC遺伝子名、NCBIやEnsemblのID番号（遺伝子、転写産物）、遺伝子の同義語、公開非公開の別による絞り込みが可能です。また、Ensembl、NCBI、UCSCのゲノムブラウザが利用可能です。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "LRG"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "European Bioinformatics Institute (EMBL-EBI)"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "European Bioinformatics Institute (EMBL-EBI)"
+                        }
+                      }
+                    },
+                    "mbgd_gene": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "MBGD is a database with a workbench system for comparative analysis of completely sequenced microbial genomes, mainly for creating orthologous or homologous gene cluster tables. MBGD classifies genomes by the hierarchical clustering method known as UPGMA, using precomputed similarity relationships identified by all-against-all BLAST search. Users can change the set of organisms or cutoff parameters to create their own orthologous groupings. Thus comparative genomics is facilitated from various points of view such as ortholog identification, paralog clustering, motif analysis and gene order comparison."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "オーソログ解析に基づいて微生物ゲノムの比較解析を行うためのデータベースです。公開されたゲノム全体を含む標準オーソログテーブルに基づいて、各オーソロググループの系統プロファイルの比較などを行えるほか、動的なオーソログ解析機能によって、利用者自身が持つゲノム配列も含めて、興味のある生物種セットに対象を絞った比較を行うこともできます。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "MBGD"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "National Institute for Basic Biology"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "自然科学研究機構　基礎生物学研究所"
+                        }
+                      }
+                    },
+                    "mbgd_organism": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "MBGD is a database with a workbench system for comparative analysis of completely sequenced microbial genomes, mainly for creating orthologous or homologous gene cluster tables. MBGD classifies genomes by the hierarchical clustering method known as UPGMA, using precomputed similarity relationships identified by all-against-all BLAST search. Users can change the set of organisms or cutoff parameters to create their own orthologous groupings. Thus comparative genomics is facilitated from various points of view such as ortholog identification, paralog clustering, motif analysis and gene order comparison."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "オーソログ解析に基づいて微生物ゲノムの比較解析を行うためのデータベースです。公開されたゲノム全体を含む標準オーソログテーブルに基づいて、各オーソロググループの系統プロファイルの比較などを行えるほか、動的なオーソログ解析機能によって、利用者自身が持つゲノム配列も含めて、興味のある生物種セットに対象を絞った比較を行うこともできます。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "MBGD"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "National Institute for Basic Biology"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "自然科学研究機構　基礎生物学研究所"
+                        }
+                      }
+                    },
+                    "meddra": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "MedDRA is a standardized medical terminology for regulatory information of medical products. It is available for use in the registration, documentation and safety monitoring of medical products. It is provided in many languages, which are Chinese, Czech, Dutch, French, German, Hungarian, Italian, Japanese, Korean, Portuguese, Portuguese - Brazilian, Russian, and Spanish in addition to English Master."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "MedDRAは人間が使用する医薬品の規制情報を国際的に共有しやすくするために作成された、標準化された国際医療用語集です。英語版の他に、中国語、チェコ語、オランダ語、フランス語、ドイツ語、ハンガリー語、イタリア語、日本語、韓国語、ポルトガル語、ポルトガル語（ブラジル語）、ロシア語、スペイン語で提供されています。英国の医薬品医療製品規制庁（MHRA）に属する用語に基づいて、WHOを含むICHパートナーによって開発されました。サブスクリプションレベルにより有償・無償が異なります。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "MedDRA"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "The International Council for Harmonisation of Technical Requirements for Pharmaceuticals for Human Use (ICH)"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "医薬品規制調和国際会議（ICH）"
+                        }
+                      }
+                    },
+                    "medgen": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "MedGen is a portal database about conditions and phenotypes related to Medical Genetics. It aggregates terms from the NIH Genetic Testing Registry (GTR), UMLS, HPO, Orphanet, ClinVar and other sources into concepts, and assigns a unique identifier and a preferred name and symbol. Each entry includes names, identifiers used by other databases, mode of inheritance, clinical features, and map location of the loci affecting the disorder. This database provides links to such resources as:\nGenetic tests registered in the NIH Genetic Testing Registry (GTR), GeneReviews, ClinVar, OMIM, Related genes, Disorders with similar clinical features, Medical and research literature, Practice guidelines, Consumer resources, Ontologies such as HPO and ORDO."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "遺伝医学に関連する症状や表現型に関する情報を集約したポータルデータベースです。NIHのGTR、UMLS、HPO、Orphanet、ClinVar、その他のソースから得られた用語を概念に集約し、一意の識別子（CUI）と優先名を割り当てます。 各エントリーには、名称、他のデータベースで使用される識別子、遺伝様式、臨床的特徴、疾患に影響を与える遺伝子座の地図上の位置が含まれます。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "MedGen"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information (NCBI)"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information (NCBI)"
+                        }
+                      }
+                    },
+                    "mesh": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "This is a database of keywords representing the content of articles and biological information. The keywords are structured in layers to allow users to find more detailed information or perform abstract searches."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "文献や、生物学情報の内容を表すキーワードのデータベースです。このキーワードを利用することで関連する生物学情報を得ることができます。キーワードは階層構造をなしており、より詳細に情報をたどることも、より抽象的な検索をすることも可能です。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "MeSH"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        }
+                      }
+                    },
+                    "mgi": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "This is a comprehensive site for mouse research. The site contains detailed information on mouse genes, gene expression data, polymorphisms and mutations, pathways, data on model rats for hereditary cancers, and phenotypes of each mouse model system. They have developed and provided The Human - Mouse: Disease Connection (HMDC) and Mammalian Phenotype Ontology."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "マウス研究の総合サイトです。マウス遺伝子に関する情報の他、遺伝子発現データ、多型・変異情報、パスウエイ、遺伝性癌症候群モデルラットに関するデータ、マウス各系統の表現型に関する詳細な情報等を提供しています。Mammalian Phenotype Ontology を作成管理しており、 オントロジーの検索・閲覧もできます(http://www.informatics.jax.org/vocab/mp_ontology) 。Human - Mouse: Disease Connection (HMDC) により、ヒトとマウスの遺伝子や表現型を統合して検索ができます。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "MGI"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "The Jackson Laboratory"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "The Jackson Laboratory"
+                        }
+                      }
+                    },
+                    "mirbase": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "miRBase is a database for published microRNA sequences and annotations, which include mature miRNA sequences (indicated by miR), and hairpin structures predicted by sequences that are precursors for miRNA (indicated by mir). A variety of search methods can be used, including by keyword, genomic position, cluster, expression data, and user-provided sequences. Furthermore, these sequences and annotations can be downloaded."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "公開されているmicroRNAの配列について、配列から予測されるmiRNA前駆体のヘアピン構造(mirで示されます)、成熟miRNAの配列(miRで示されます)、文献情報等が登録されています。様々な検索機能が用意されており、キーワード検索、ゲノム位置による検索、クラスター検索、発現実験による検索、ユーザ自身の配列による検索が行えます。全ての配列とアノテーションはダウンロード可能です。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "miRBase"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "Faculty of Life Sciences(The University of Manchester)"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "Faculty of Life Sciences (The University of Manchester)"
+                        }
+                      }
+                    },
+                    "mondo": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "Mondo is an ontology for integrating disease definitions. It collects disease definitions and data models from numerous sources, which include HPO, OMIM, SNOMED CT, ICD, PhenoDB, MedDRA, MedGen, ORDO, DO, GARD, etc. It provides a hierarchical structure which can be used for classification or \"rolling up\" diseases to higher level groupings."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "疾病の定義を統合して構築したオントロジーです。疾病を定義しデータモデルを収録している多くのデータベース（HPO、OMIM、SNOMED CT、ICD、PhenoDB、MedDRA、MedGen、ORDO、DO、GARDなど）から情報を収集しています。開発当初は半自動で構築されていましたが、広範囲に渡り手動でキュレーションされるようになってきています。疾病の個々の症状、特徴の説明はHPOに準拠しており、疾病は階層構造で表示できます。OWL形式を利用したmondo-with-equivalent、obo、jsonの３つのフォーマットで利用可能です。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "MONDO"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "Monarch Initiative"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "Monarch Initiative"
+                        }
+                      }
+                    },
+                    "nando": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "NanbyoData provides informative data related to intractable diseases using Nanbyo Disease Ontology (NANDO). Designated intractable diseases and chronic specific pediatric diseases in Japan are the subject diseases. NANDO, and genes and phenotypes related intractable diseases are downloadable."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "NanbyoDataは難病オントロジー（Nanbyo Disease Ontology, NANDO）を介して国内外の難病関連情報を集積したサイトです。日本の難病関連制度である指定難病・小児慢性特定疾病の対象疾患に関して詳細な分類までを網羅し、その概要（日英）とOMIM、Orphanet、MedGen、Monarch Initiative、KEGG Diseaseへのリンク情報を提供しています。NANDOはサイトからダウンロードして利用できる他、語彙一覧 (http://nanbyodata.jp/ontology/nando) と階層構造 (http://bioportal.bioontology.org/ontologies/NANDO/?p=classes&conceptid=root) がweb上から参照できます。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "NanbyoData"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "Research Organization of Information and Systems Database Center for Life Science"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "情報・システム研究機構　ライフサイエンス統合データベースセンター"
+                        }
+                      }
+                    },
+                    "ncbigene": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "The gene database provides information on gene sequence, structure, location, and function for annotated genes from the NCBI database. Users can search by accession ID or keyword, compare and identify sequences using BLAST, or submit references into function (RIFs) based on experimental results. Bulk download and an update mailing list are available."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "生物種別の遺伝子単位でエントリーを構成しており、NCBIの様々なデータベースを統合的に利用して遺伝子情報を掲載しています。染色体上の位置、配列、発現、構造、機能、ホモロジーデータのような遺伝子をベースとした情報を提供しています。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "NCBI Gene"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        }
+                      }
+                    },
+                    "ncbiprotein": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "NCBI is a portal site for US biological study data. The site contains links to several NIH research resources, most of which are repositories for submission of data from government-funded and/or published projects. Users can search the entire NCBI collection or perform keyword searches of a specific database from the NCBI search bar. Constituent databases contain a wealth of data for download."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "NCBI（米国立バイオテクノロジー情報センター）は、NIH（米国立衛生研究所）のNLM（米国立医学図書館）の一部門として1988年に設立されたバイオインフォマティクス研究組織です。1989年にBLAST、1990年に検索システムEntrezを開発しました。現在では、NCBI内の各種データベースに対する検索を統一的なインタフェースで行えるようにしています。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "NCBI"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        }
+                      }
+                    },
+                    "oma_group": {
+                      "type": "object"
+                    },
+                    "oma_protein": {
+                      "type": "object"
+                    },
+                    "omim_gene": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "OMIM is a database of human disease and genetic information and the online representation of Mendelian Inheritance in Man, a project initiated in the 1960s. The database summarizes heritable traits and provides information on both the trait and experimentally determined genetic causes. The database is manually curated by experts and can be searched by OMIM ID, gene, disease, or phenotype."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "Johns Hopkins大学のVictor A. McKusick 博士が中心となって記述、編集を行っている、ヒトの遺伝子変異と遺伝病のデータベースです。全ての既知のメンデル型遺伝病と12,000以上の遺伝子に関して、テキスト形式の情報やリファレンスが示されます。MEDLINEやEntrezのリンクも含まれます。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "OMIM"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        }
+                      }
+                    },
+                    "omim_phenotype": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "OMIM is a database of human disease and genetic information and the online representation of Mendelian Inheritance in Man, a project initiated in the 1960s. The database summarizes heritable traits and provides information on both the trait and experimentally determined genetic causes. The database is manually curated by experts and can be searched by OMIM ID, gene, disease, or phenotype."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "Johns Hopkins大学のVictor A. McKusick 博士が中心となって記述、編集を行っている、ヒトの遺伝子変異と遺伝病のデータベースです。全ての既知のメンデル型遺伝病と12,000以上の遺伝子に関して、テキスト形式の情報やリファレンスが示されます。MEDLINEやEntrezのリンクも含まれます。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "OMIM"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        }
+                      }
+                    },
+                    "orphanet": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "Orphanet is a portal site for rare diseases and orphan drugs. It provides inventory of rare diseases and classification, inventory of orphan drugs, clinical trials, etc."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "Orphanetは希少疾患患者の診断と治療の向上を図ることを目的とした、希少疾患や希少疾患用医薬品について様々な情報を参照可能にしたデータベースです。疾患や薬に関する一般的な情報をはじめとして、臨床試験情報、関連する論文や、有病率、発症歴、症状、地域情報などを検索可能です。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "Orphanet"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "Orphanet"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "フランス国立保健医学研究所"
+                        }
+                      }
+                    },
+                    "pdb": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "This is an international public repository for three-dimensional structures and structure coordinates (conformations) of proteins and nucleic acids, and the central database for biological structural data. Data obtained through X-ray crystallography and NMR experiments are stored in PDB. In addition to three-dimensional information of proteins, users can find amino acid sequences, protein-related information on GO, and other compounds bound to the protein."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "タンパク質と核酸の３次元構造の構造座標（立体配座）を蓄積している国際的な公共レポジトリです。\n　RCSB PDB （https://integbio.jp/dbcatalog/record/nbdc01865 ）\n　PDBe （https://integbio.jp/dbcatalog/record/nbdc00613 ）\n　PDBj （https://integbio.jp/dbcatalog/record/nbdc00157 ）\n　BMRB （https://integbio.jp/dbcatalog/record/nbdc00380 ）\n上記４つデータベースの集合体として、X線結晶構造解析やNMRなどで実験的に決定されたタンパク質の立体構造データの他に、アミノ酸配列、GOといったタンパク質に関する情報やタンパク質に結合している化合物の情報を統合し提供しています。検証データ登録のためのツールや登録データのダウンロードが可能なFTPサイトを装備しています。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "wwPDB"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "wwPDB consortium"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "wwPDB consortium"
+                        }
+                      }
+                    },
+                    "pfam": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "Pfam Version 26.0 is a comprehensive database of protein families containing multiple sequence alignments and HMMs.\nThis repository provides data on 13,672 protein families.\nThe site can be searched with a known protein sequence for matching families. \nOptions to search for a Pfam family, clan, sequence or structure are available.\nA keyword search option is also provided."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "現在最もよく整備されたタンパク質ドメインデータベースの一つで、膨大な数のタンパク質ファミリーのコレクションを保持しています。手作業で分類を行った高品質のPfam-Aと、機械的に分類を行ったPfam-Bから構成されています。最大の特徴は、検索システムとしてHMMERというプログラムを使用している点であり、これにより高速で精度の高いモチーフの検索を可能にしています。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "Pfam"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "EMBL-EBI"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "EMBL-EBI"
+                        }
+                      }
+                    },
+                    "pubchem_compound": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "PubChem Compound is a database of chemical structrues of validated small molecules. The dataase contains entries for PubChem entities which are grouped by structural identity and similarity. Users can submit compounds and download via FTP."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "化合物名や分子量、CompoundIDなどで化合物の情報を検索することができるサイトです。医薬品名やその効能、LogP値などの物性値も掲載されています。また、類似構造を持つ別の化合物の検索も可能です。PubChem Substanceが一つの化合物に対して異なる情報をもつ複数のエントリをもつ可能性があるのに対し、PubChem CompoundはPubChem Substanceで得られた種々の情報を一つのエントリに集約して提供しています。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "PubChem Compound"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        }
+                      }
+                    },
+                    "pubchem_substance": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "PubChem Substance is a database of samples of chemical entities which links to the biological activity of those samples in PubChem BioAssay. The database contains structural information on substances with links to further information in cases where the substance has been more fully characterized. It consists of records of chemical entities deposited by various contributors, so a chemical entity may be described different records with different data in this database."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "PubChem Substanceは、出版社、研究者、化学ベンダー、製薬会社、および多くの重要なケミカルバイオロジーリソースをもつ研究者によって提供された化学物質とその生物活性に関する情報のオープンアーカイブです。特定の化学物質に関して個々の提供者からの情報が含まれており、１つの化合物に対して提供者が異なる別のレコードとして異なる情報を提供している可能性があります。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "PubChem Substance"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        }
+                      }
+                    },
+                    "pubmed": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "This database contains bibliographic information from journal articles in the field of life science as well as MEDLINE (title, authors, journal name, abstracts). Links are provided for articles with free access to the full article."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "MEDLINEおよび生命科学分野のジャーナル文献の書誌情報（タイトル、著者名、雑誌名、抄録など）を収録したデータベースです。全文をフリーで公開している文献については、提供サイトへのリンクが張られています。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "PubMed"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        }
+                      }
+                    },
+                    "reactome_pathway": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "REACTOME is a database of human pathways for basic research, genome analysis, pathway modeling, systems biology and education. It contains manually curated and peer-reviewed pathway data which are annotated by expert biologists, in collaboration with Reactome editorial staff and cross-referenced to many bioinformatics databases. This database provides an intuitive website to navigate pathway knowledge and a suite of data analysis tools to support the pathway-based analysis of complex experimental and computational data sets. The curated  human pathway data are available to infer orthologous events in 20 non-human species including mouse, rat, chicken, worm, fly, yeast, plant and bacteria. Using species comparison tool, users are able to compare predicted pathways with those of human to find reactions and pathways common to a selected species and human."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "ヒトの生体内の主要反応経路や生化学反応を整備したデータベースです。ヒト以外の20生物種のデータも格納しており、ヒトとの比較ができます。ここに収録されている情報は、それぞれの分野の専門家が編集しているため、非常に信頼性の高いデータベースです。代謝パスウェイ、シグナル伝達や膜輸送、感染など様々なパスウェイが扱われており、SBGN (Sytem Biology Graphical Notation)形式で視覚化されています。パスウエイ解析、生物種間比較、発現解析も行えます。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "REACTOME"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "Reactome team"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "Reactome Team"
+                        }
+                      }
+                    },
+                    "reactome_reaction": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "REACTOME is a database of human pathways for basic research, genome analysis, pathway modeling, systems biology and education. It contains manually curated and peer-reviewed pathway data which are annotated by expert biologists, in collaboration with Reactome editorial staff and cross-referenced to many bioinformatics databases. This database provides an intuitive website to navigate pathway knowledge and a suite of data analysis tools to support the pathway-based analysis of complex experimental and computational data sets. The curated  human pathway data are available to infer orthologous events in 20 non-human species including mouse, rat, chicken, worm, fly, yeast, plant and bacteria. Using species comparison tool, users are able to compare predicted pathways with those of human to find reactions and pathways common to a selected species and human."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "ヒトの生体内の主要反応経路や生化学反応を整備したデータベースです。ヒト以外の20生物種のデータも格納しており、ヒトとの比較ができます。ここに収録されている情報は、それぞれの分野の専門家が編集しているため、非常に信頼性の高いデータベースです。代謝パスウェイ、シグナル伝達や膜輸送、感染など様々なパスウェイが扱われており、SBGN (Sytem Biology Graphical Notation)形式で視覚化されています。パスウエイ解析、生物種間比較、発現解析も行えます。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "REACTOME"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "Reactome team"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "Reactome Team"
+                        }
+                      }
+                    },
+                    "refseq_genomic": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "RefSeq is a database of standard reference genomic, transcript, and protein sequences. The database contains consensus sequence data for over 20,000 organisms and over 27 million proteins and is designed to provide a common basis for experimental studies that can be searched using accession ID, keyword, or BLAST. Bulk data is available for FTP download."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "異なる生物種由来の冗長性を排除したDNA, RNA, タンパク配列を収録したデータベースです。プラスミド、オルガネラ、ウイルス、古細菌、真正細菌、真核生物のアノテーション付けされた配列が含まれています。生物種ごとに、標準となる配列の包括的データセットを提供することを目的としています。配列の情報源はGenBank由来ですが、それらの中から情報を統合して標準となる配列を提供しています。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "RefSeq"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        }
+                      }
+                    },
+                    "refseq_protein": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "RefSeq is a database of standard reference genomic, transcript, and protein sequences. The database contains consensus sequence data for over 20,000 organisms and over 27 million proteins and is designed to provide a common basis for experimental studies that can be searched using accession ID, keyword, or BLAST. Bulk data is available for FTP download."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "異なる生物種由来の冗長性を排除したDNA, RNA, タンパク配列を収録したデータベースです。プラスミド、オルガネラ、ウイルス、古細菌、真正細菌、真核生物のアノテーション付けされた配列が含まれています。生物種ごとに、標準となる配列の包括的データセットを提供することを目的としています。配列の情報源はGenBank由来ですが、それらの中から情報を統合して標準となる配列を提供しています。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "RefSeq"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        }
+                      }
+                    },
+                    "refseq_rna": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "RefSeq is a database of standard reference genomic, transcript, and protein sequences. The database contains consensus sequence data for over 20,000 organisms and over 27 million proteins and is designed to provide a common basis for experimental studies that can be searched using accession ID, keyword, or BLAST. Bulk data is available for FTP download."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "異なる生物種由来の冗長性を排除したDNA, RNA, タンパク配列を収録したデータベースです。プラスミド、オルガネラ、ウイルス、古細菌、真正細菌、真核生物のアノテーション付けされた配列が含まれています。生物種ごとに、標準となる配列の包括的データセットを提供することを目的としています。配列の情報源はGenBank由来ですが、それらの中から情報を統合して標準となる配列を提供しています。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "RefSeq"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        }
+                      }
+                    },
+                    "rgd": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "This is a comprehensive site for rat genome researches. In addition to information on rat genes, the site contains information on rat strains, data on rat models for disease, and publications."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "ラットゲノム研究の総合サイトです。ラット遺伝子に関する情報の他に、ラットの系統に関する情報、病態モデルラットに関するデータ、文献情報等を提供しています。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "RGD"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "Medical College of Wisconsin/Bioinformatics Research Center"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "Medical College of Wisconsin/Bioinformatics Research Center"
+                        }
+                      }
+                    },
+                    "rhea": {
+                      "type": "object"
+                    },
+                    "sra_accession": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "SRA is a database of raw sequence reads from next-generation sequencing systems. The database contains millions of unannotated raw reads generated from a variety of projects. Data can be submitted to the archive or downloaded via FTP."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "次世代シーケンサーによる配列データのレポジトリサイトです。現在扱っているプラットフォームは454(ロシュ)、Genome Analyzer(イルミナ)、SOLiD(アプライドバイオシステムズ)、Heliscope(ヘリコス)。研究単位でデータの登録、配布を行っています。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "SRA"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        }
+                      }
+                    },
+                    "sra_analysis": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "SRA is a database of raw sequence reads from next-generation sequencing systems. The database contains millions of unannotated raw reads generated from a variety of projects. Data can be submitted to the archive or downloaded via FTP."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "次世代シーケンサーによる配列データのレポジトリサイトです。現在扱っているプラットフォームは454(ロシュ)、Genome Analyzer(イルミナ)、SOLiD(アプライドバイオシステムズ)、Heliscope(ヘリコス)。研究単位でデータの登録、配布を行っています。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "SRA"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        }
+                      }
+                    },
+                    "sra_experiment": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "SRA is a database of raw sequence reads from next-generation sequencing systems. The database contains millions of unannotated raw reads generated from a variety of projects. Data can be submitted to the archive or downloaded via FTP."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "次世代シーケンサーによる配列データのレポジトリサイトです。現在扱っているプラットフォームは454(ロシュ)、Genome Analyzer(イルミナ)、SOLiD(アプライドバイオシステムズ)、Heliscope(ヘリコス)。研究単位でデータの登録、配布を行っています。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "SRA"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        }
+                      }
+                    },
+                    "sra_project": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "SRA is a database of raw sequence reads from next-generation sequencing systems. The database contains millions of unannotated raw reads generated from a variety of projects. Data can be submitted to the archive or downloaded via FTP."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "次世代シーケンサーによる配列データのレポジトリサイトです。現在扱っているプラットフォームは454(ロシュ)、Genome Analyzer(イルミナ)、SOLiD(アプライドバイオシステムズ)、Heliscope(ヘリコス)。研究単位でデータの登録、配布を行っています。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "SRA"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        }
+                      }
+                    },
+                    "sra_run": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "SRA is a database of raw sequence reads from next-generation sequencing systems. The database contains millions of unannotated raw reads generated from a variety of projects. Data can be submitted to the archive or downloaded via FTP."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "次世代シーケンサーによる配列データのレポジトリサイトです。現在扱っているプラットフォームは454(ロシュ)、Genome Analyzer(イルミナ)、SOLiD(アプライドバイオシステムズ)、Heliscope(ヘリコス)。研究単位でデータの登録、配布を行っています。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "SRA"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        }
+                      }
+                    },
+                    "sra_sample": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "SRA is a database of raw sequence reads from next-generation sequencing systems. The database contains millions of unannotated raw reads generated from a variety of projects. Data can be submitted to the archive or downloaded via FTP."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "次世代シーケンサーによる配列データのレポジトリサイトです。現在扱っているプラットフォームは454(ロシュ)、Genome Analyzer(イルミナ)、SOLiD(アプライドバイオシステムズ)、Heliscope(ヘリコス)。研究単位でデータの登録、配布を行っています。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "SRA"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        }
+                      }
+                    },
+                    "taxonomy": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "Taxonomy is a database of systematic classifications of organisms repesented in public sequencing databases. The database contains phylogenetic relatonships and nomenclature for an estimated 10% of all living species. Tools include a browser, genetic codes, and a common evolutionary tree. Taxonomic classificatinos can be downloaded via FTP."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "NCBI Entrezデータベースに少なくとも1件以上登録されている全ての生物種と上位分類名を収集したデータベースです。160,000以上の生物種が登録されています。各エントリーには、学名、英名、階層分類、上位階層、Entrezデータベース群の収録数とリンクが含まれています。このデータベースは、種々のデータベース間で生物名の表記を統一することを目的として構築しており、分類学や系統発生学の権威となるものではありません。採用されている生物名や系統分類は、分類学的、系統発生学的に普及している内容と異なる場合があります。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "Taxonomy - NCBI"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "National Center for Biotechnology Information"
+                        }
+                      }
+                    },
+                    "togovar": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "TogoVar (NBDC's integrated database of Japanese genomic variation) is a database that has collected and organized genome sequence differences between individuals (variants) in the Japanese population and disease information associated with them. TogoVar provides variant frequencies in the Japanese population that have been aggregated across research projects. Two available datasets, JGA-NGS and JGA-SNP, are obtained by aggregating individual genomic data that have been registered in the NBDC Human Database / Japanese Genotype-phenotype Archive (JGA). In addition, TogoVar integrates information related to genotypes or phenotypes that has been compiled independently in a variety of different databases and provides information for interpreting variants in a one-stop, easy-to-understand manner.\nUsers can learn how to use it by a movie: https://togotv.dbcls.jp/en/20181012.html"
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "TogoVar（日本人ゲノム多様性統合データベース）は、日本人ゲノム配列の個人による違い（バリアント）とそれに関係する疾患情報などを収集・整理したデータベースです。TogoVarは、研究プロジェクト横断的に集約した日本人におけるバリアントの頻度情報を提供します。利用可能な２つのデータセットであるJGA-NGSとJGA-SNPはNBDCヒトデータベース/Japanese Genotype-phenotype Archive (JGA)に登録されている個人ごとのゲノムデータを集約して得られた頻度情報です。さらに、多種多様なデータベースに散在して収録されてきた遺伝子型や表現型に関連する情報を整理統合し、バリアントを解釈するための情報をワンストップでわかりやすく提供します。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "TogoVar"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "National Bioscience Database Center"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "国立研究開発法人科学技術振興機構　バイオサイエンスデータベースセンター"
+                        }
+                      }
+                    },
+                    "uniprot": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "This database contains information on amino acid sequences and their functions. It is composed of four core databases, UniProtKB, UniRef, UniParc, and Proteomes. UniProtKB contains two types of data, which are manually curated high quality SwissProt annotations based on literature information, and automatically annotated TrEMBL. \r\nUniRef provides results of sequence similarity searches. \r\nUniParc integrates information such as ID for other databases per sequence ID.\r\nProteomes provides proteome data of each organism with completely sequenced genomes."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "アミノ酸配列とその機能情報を掲載している代表的なデータベースです。「UniProtKB」、「UniRef」、「UniParc」の3種類のデータベースから構成されています。\nUniProtKB: 文献情報などを元に手作業で高品質のアノテーションを付けたSwissProtと、機械的にアノテーションを加えたTrEMBLを公開しています。\nUniRef: あらかじめ行われた配列相同性検索の結果を提供しています。\nUniParc: 配列IDごとに他のデータベースのID等の情報をまとめています。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "UniProt"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "UniProt Consortium"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "UniProt Consortium"
+                        }
+                      }
+                    },
+                    "uniprot_mnemonic": {
+                      "properties": {
+                        "description_en": {
+                          "type": "string",
+                          "example": "This database contains information on amino acid sequences and their functions. It is composed of four core databases, UniProtKB, UniRef, UniParc, and Proteomes. UniProtKB contains two types of data, which are manually curated high quality SwissProt annotations based on literature information, and automatically annotated TrEMBL. \r\nUniRef provides results of sequence similarity searches. \r\nUniParc integrates information such as ID for other databases per sequence ID.\r\nProteomes provides proteome data of each organism with completely sequenced genomes."
+                        },
+                        "description_ja": {
+                          "type": "string",
+                          "example": "アミノ酸配列とその機能情報を掲載している代表的なデータベースです。「UniProtKB」、「UniRef」、「UniParc」の3種類のデータベースから構成されています。\nUniProtKB: 文献情報などを元に手作業で高品質のアノテーションを付けたSwissProtと、機械的にアノテーションを加えたTrEMBLを公開しています。\nUniRef: あらかじめ行われた配列相同性検索の結果を提供しています。\nUniParc: 配列IDごとに他のデータベースのID等の情報をまとめています。"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "UniProt"
+                        },
+                        "organization_en": {
+                          "type": "string",
+                          "example": "UniProt Consortium"
+                        },
+                        "organization_ja": {
+                          "type": "string",
+                          "example": "UniProt Consortium"
+                        }
+                      }
+                    },
+                    "wikipathways": {
+                      "type": "object"
                     }
-                  },
-                  "wikipathways": {
-                    "type": "object"
                   }
                 }
               }
-            },
-            "400": {
-              "description": "Bad request"
             }
+          },
+          "400": {
+            "description": "Bad request"
           }
         }
       }
     }
   }
+}

--- a/swagger/oas.json
+++ b/swagger/oas.json
@@ -1,0 +1,10086 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+      "title": "TogoID API",
+      "version": "2.0.0"
+    },
+    "host": "api.togoid.dbcls.jp",
+    "schemes": [
+      "https"
+    ],
+    "produces": [
+      "application/json"
+    ],
+    "tags": [
+      {
+        "name": "convert"
+      },
+      {
+        "name": "count"
+      },
+      {
+        "name": "config"
+      }
+    ],
+    "paths": {
+      "/convert": {
+        "get": {
+          "tags": [
+            "convert"
+          ],
+          "summary": "Convert IDs",
+          "operationId": "convertId",
+          "parameters": [
+            {
+              "name": "ids",
+              "in": "query",
+              "type": "string",
+              "description": "A comma-separated list of source IDs.",
+              "required": true
+            },
+            {
+              "name": "route",
+              "in": "query",
+              "type": "string",
+              "description": "A comma-separated list of datasets, starts with the source dataset and ends with the target dataset.",
+              "required": true
+            },
+            {
+              "name": "report",
+              "in": "query",
+              "type": "string",
+              "enum": [
+                "all",
+                "pair",
+                "target",
+                "full"
+              ],
+              "default": "target",
+              "description": "The output type can be selected from the following: 'target' (includes target IDs only), 'pair' (includes source and target IDs), 'all' (all converted IDs including source, target, and intermediate IDs of the route), or 'full' (all IDs including unconverted IDs)."
+            },
+            {
+              "name": "format",
+              "in": "query",
+              "type": "string",
+              "enum": [
+                "csv",
+                "tsv",
+                "json"
+              ],
+              "default": "json",
+              "description": "The output format can be selected from 'tsv', 'csv', or 'json'."
+            },
+            {
+              "name": "limit",
+              "in": "query",
+              "type": "integer",
+              "default": 10000,
+              "maximum": 10000,
+              "description": "The maximum number of results to be returned."
+            },
+            {
+              "name": "offset",
+              "in": "query",
+              "type": "integer",
+              "default": 0,
+              "description": "The position to start after the specified number of results."
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "successful operation",
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "ids": {
+                    "type": "string",
+                    "example": [
+                      "26199",
+                      "38937",
+                      "14027",
+                      "21498",
+                      "18185",
+                      "1314",
+                      "25960",
+                      "2206",
+                      "22224",
+                      "19741"
+                    ]
+                  },
+                  "route": {
+                    "type": "string",
+                    "example": [
+                      "hgnc",
+                      "ensembl_gene"
+                    ]
+                  },
+                  "result": {
+                    "type": "string",
+                    "example": [
+                      "ENSG00000100364",
+                      "ENSG00000154719",
+                      "ENSG00000116285",
+                      "ENSG00000179454",
+                      "ENSG00000085978",
+                      "ENSG00000081052",
+                      "ENSG00000006459",
+                      "ENSG00000198088",
+                      "ENSG00000134152",
+                      "ENSG00000284140"
+                    ]
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request"
+            }
+          }
+        }
+      },
+      "/count/{source}-{target}": {
+        "get": {
+          "tags": [
+            "count"
+          ],
+          "summary": "Count IDs",
+          "operationId": "countId",
+          "parameters": [
+            {
+              "name": "source",
+              "in": "path",
+              "type": "string",
+              "description": "A key from https://github.com/dbcls/togoid-config/blob/main/config/dataset.yaml",
+              "required": true
+            },
+            {
+              "name": "target",
+              "in": "path",
+              "type": "string",
+              "description": "A key from https://github.com/dbcls/togoid-config/blob/main/config/dataset.yaml",
+              "required": true
+            },
+            {
+              "name": "ids",
+              "in": "query",
+              "type": "string",
+              "description": "List IDs separated by commas",
+              "required": true
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "successful operation",
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "source": {
+                    "type": "string",
+                    "example": 2
+                  },
+                  "target": {
+                    "type": "string",
+                    "example": 2
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request"
+            }
+          }
+        }
+      },
+      "/config/dataset": {
+        "get": {
+          "tags": [
+            "config"
+          ],
+          "summary": "Get all dataset config",
+          "operationId": "getAllDataset",
+          "responses": {
+            "200": {
+              "description": "successful operation",
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "affy_probeset": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "Affymetrix probeset"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>\\d{3,}(?:_[a-z])?_at)$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/affy.probeset/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "FIXME"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Probe"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "1553582_a_at",
+                            "211531_x_at",
+                            "202573_at",
+                            "201640_x_at",
+                            "205117_at",
+                            "201017_at",
+                            "205099_s_at",
+                            "200614_at",
+                            "201895_at",
+                            "202666_s_at"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "bioproject": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "BioProject"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>PRJ[DEN][A-Z]\\d+)$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/bioproject/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00476"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Project"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "PRJDB575",
+                            "PRJDB1880",
+                            "PRJDB478",
+                            "PRJDA45949",
+                            "PRJEB6285",
+                            "PRJEA28961",
+                            "PRJEB2222",
+                            "PRJNA30641",
+                            "PRJNA68235",
+                            "PRJNA42549"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "biosample": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "BioSample"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>SAM[NED]\\w?\\d+)$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/biosample/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc01983"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Sample"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "SAMD00003683",
+                            "SAMD00006315",
+                            "SAMD00003741",
+                            "SAMD00011226",
+                            "SAMN13091859",
+                            "SAMN05877962",
+                            "SAMN05877838",
+                            "SAMEA104232303",
+                            "SAMEA4760552",
+                            "SAMEA1572228"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "ccds": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "Consensus CDS"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>CCDS\\d+)(?:\\.\\d+)?$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/ccds/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00023"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Gene"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "CCDS1471",
+                            "CCDS10913",
+                            "CCDS14790",
+                            "CCDS35175",
+                            "CCDS2395",
+                            "CCDS58412",
+                            "CCDS55555",
+                            "CCDS34401",
+                            "CCDS41889",
+                            "CCDS9052"
+                          ],
+                          [
+                            "CCDS1471.1",
+                            "CCDS10913.1",
+                            "CCDS14790.1",
+                            "CCDS35175.2",
+                            "CCDS2395.1",
+                            "CCDS58412.1",
+                            "CCDS55555.1",
+                            "CCDS34401.2",
+                            "CCDS41889.1",
+                            "CCDS9052.1"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "chebi": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "ChEBI compound"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?:CHEBI[:_])?(?<id>\\d+)$"
+                      },
+                      "format": {
+                        "type": "string",
+                        "example": [
+                          "%s",
+                          "CHEBI:%s",
+                          "CHEBI_%"
+                        ]
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://purl.obolibrary.org/obo/CHEBI_"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00027"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Compound"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "84824",
+                            "40167",
+                            "32807",
+                            "87666",
+                            "57524",
+                            "64860",
+                            "94440",
+                            "18005",
+                            "4806",
+                            "50158"
+                          ],
+                          [
+                            "CHEBI:84824",
+                            "CHEBI:40167",
+                            "CHEBI:32807",
+                            "CHEBI:87666",
+                            "CHEBI:57524",
+                            "CHEBI:64860",
+                            "CHEBI:94440",
+                            "CHEBI:18005",
+                            "CHEBI:4806",
+                            "CHEBI:50158"
+                          ],
+                          [
+                            "CHEBI_84824",
+                            "CHEBI_40167",
+                            "CHEBI_32807",
+                            "CHEBI_87666",
+                            "CHEBI_57524",
+                            "CHEBI_64860",
+                            "CHEBI_94440",
+                            "CHEBI_18005",
+                            "CHEBI_4806",
+                            "CHEBI_50158"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "chembl_compound": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "ChEMBL compound"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>CHEMBL\\d+)$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/chembl.compound/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc02555"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Compound"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "CHEMBL121649",
+                            "CHEMBL190334",
+                            "CHEMBL3103282",
+                            "CHEMBL69329",
+                            "CHEMBL2105131",
+                            "CHEMBL2177390",
+                            "CHEMBL3091820",
+                            "CHEMBL1200335",
+                            "CHEMBL3094412",
+                            "CHEMBL67367"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "chembl_target": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "ChEMBL target"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>CHEMBL\\d+)$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/chembl.target/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc02555"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Protein"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "CHEMBL2788",
+                            "CHEMBL3091264",
+                            "CHEMBL3831324",
+                            "CHEMBL5524",
+                            "CHEMBL5597",
+                            "CHEMBL3983",
+                            "CHEMBL4187",
+                            "CHEMBL3391681",
+                            "CHEMBL5135",
+                            "CHEMBL1255130"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "civic_gene": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "CIVIC gene"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>\\d+)$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://civic.genome.wustl.edu/links/genes/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc02558"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Gene"
+                      }
+                    }
+                  },
+                  "clinvar": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "ClinVar variant"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(VCV0*)?(?<id>(\\d{1,9}))$"
+                      },
+                      "format": {
+                        "type": "string",
+                        "example": [
+                          "%s",
+                          "VCV%09d"
+                        ]
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/clinvar/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc01514"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Variant"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "658761",
+                            "619209",
+                            "745342",
+                            "11955",
+                            "731668",
+                            "724289",
+                            "725734",
+                            "743127",
+                            "789913",
+                            "5302"
+                          ],
+                          [
+                            "VCV000658761",
+                            "VCV000619209",
+                            "VCV000745342",
+                            "VCV000011955",
+                            "VCV000731668",
+                            "VCV000724289",
+                            "VCV000725734",
+                            "VCV000743127",
+                            "VCV000789913",
+                            "VCV000005302"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "dbsnp": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "dbSNP"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>rs\\d+)$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/dbsnp/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00206"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Variant"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "rs746303788",
+                            "rs1407020249",
+                            "rs374003162",
+                            "rs4647297",
+                            "rs549539526",
+                            "rs1387864740",
+                            "rs1177577242",
+                            "rs769848663",
+                            "rs16961655",
+                            "rs79135400"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "dgidb": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "DGIdb"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "FIXME"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc02562"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Interaction"
+                      }
+                    }
+                  },
+                  "doid": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "Disease ontology"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^DO(?:ID)?[:_](?<id>\\d+)$"
+                      },
+                      "format": {
+                        "type": "string",
+                        "example": [
+                          "DO:%s",
+                          "DOID:%s",
+                          "DOID_%s"
+                        ]
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://purl.obolibrary.org/obo/DOID_"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00261"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Disease"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "DO:9036",
+                            "DO:3159",
+                            "DO:10964",
+                            "DO:12698",
+                            "DO:0060459",
+                            "DO:11840",
+                            "DO:11339",
+                            "DO:914",
+                            "DO:9945",
+                            "DO:1407"
+                          ],
+                          [
+                            "DOID:9036",
+                            "DOID:3159",
+                            "DOID:10964",
+                            "DOID:12698",
+                            "DOID:0060459",
+                            "DOID:11840",
+                            "DOID:11339",
+                            "DOID:914",
+                            "DOID:9945",
+                            "DOID:1407"
+                          ],
+                          [
+                            "DOID_9036",
+                            "DOID_3159",
+                            "DOID_10964",
+                            "DOID_12698",
+                            "DOID_0060459",
+                            "DOID_11840",
+                            "DOID_11339",
+                            "DOID_914",
+                            "DOID_9945",
+                            "DOID_1407"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "drugbank": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "DrugBank"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>DB\\d{5})$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/drugbank/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc01071"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Compound"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "DB15589",
+                            "DB13471",
+                            "DB05830",
+                            "DB07423",
+                            "DB07074",
+                            "DB08912",
+                            "DB02908",
+                            "DB05088",
+                            "DB05229",
+                            "DB08910"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "ec": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "Enzyme nomenclature"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?:EC:)?(?<id>\\d+\\.(?:(?:-\\.-\\.-)|\\d+\\.(?:(?:-\\.-)|\\d+\\.(?:-|n?\\d+))))$"
+                      },
+                      "format": {
+                        "type": "string",
+                        "example": [
+                          "%s",
+                          "EC:%s"
+                        ]
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/ec-code/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc01883"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Function"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "1.6.3.1",
+                            "2.4.1.353",
+                            "1.1.1.288",
+                            "1.5.1.2",
+                            "3.1.1.71",
+                            "1.3.1.31",
+                            "3.5.1.29",
+                            "1.16.1.1",
+                            "3.1.3.48",
+                            "2.3.1.138"
+                          ],
+                          [
+                            "EC:1.6.3.1",
+                            "EC:2.4.1.353",
+                            "EC:1.1.1.288",
+                            "EC:1.5.1.2",
+                            "EC:3.1.1.71",
+                            "EC:1.3.1.31",
+                            "EC:3.5.1.29",
+                            "EC:1.16.1.1",
+                            "EC:3.1.3.48",
+                            "EC:2.3.1.138"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "ena": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "ENA"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?:ena\\.embl:)?(?<id>[A-Z]+[0-9]+)(?:\\.\\d+)?$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/ena.embl/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00432"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Gene"
+                      }
+                    }
+                  },
+                  "ensembl_gene": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "Ensembl gene"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?:(?:(?<id1>ENS[A-Z]*G\\d{11})(?:\\.\\d+)?)|(?<id2>FBgn\\d{7})|(?:(?<id3>MGP_[A-Za-z0-9]+_G\\d{7})(?:\\.\\d+)?)|(?<id4>LRG_\\d+)|(?<id5>WBGene\\d{8})|(?<id6>Y[A-Z]{2}\\d{3}[A-Z](?:-[A-Z])?)|(?<id7>Q\\d{4})|(?<id8>[A-Z]{3}\\d{1,3}(?:-\\d)?)|(?<id9>snR\\d+-?[A-Za-z]?)|(?<id10>t[A-Z]\\([ACGUX]{3}\\)[A-Z]\\d?))$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/ensembl/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00054"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Gene"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "ENSG00000186283",
+                            "ENSAMEG00000018238",
+                            "ENSG00000167916",
+                            "ENSG00000213417",
+                            "ENSG00000133328",
+                            "ENSG00000274404",
+                            "ENSG00000184363",
+                            "FBgn0021742",
+                            "FBgn0030057",
+                            "FBgn0265139"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "ensembl_protein": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "Ensembl protein"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?:(?:(?<id1>ENS[A-Z]*P\\d{11})(?:\\.\\d+)?)|(?<id2>FBpp\\d{7})|(?:(?<id3>MGP_[A-Za-z0-9]+_P\\d{7})(?:\\.\\d+)?)|(?<id4>LRG_\\d+p\\d+(?:-\\d)?)|(?<id5>(?:[A-Za-z0-9][A-Za-z0-9_]+)\\.t?\\d+[a-z]?(?:\\.\\d+)?)|(?<id6>Y[A-Z]{2}\\d{3}[A-Z](?:-[A-Z])?)|(?<id7>Q\\d{4}))$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/ensembl/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00054"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Protein"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "ENSP00000365411",
+                            "ENSP00000420674",
+                            "ENSAZOP00000020796",
+                            "FBpp0070277",
+                            "FBpp0070535",
+                            "ENSAZOP00000019433",
+                            "ENSP00000372042",
+                            "ENSAZOP00000017910",
+                            "ENSP00000370977",
+                            "ENSP00000481894"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "ensembl_transcript": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "Ensembl transcript"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?:(?:(?<id1>ENS[A-Z]*T\\d{11})(?:\\.\\d+)?)|(?<id2>FBtr\\d{7})|(?:(?<id3>MGP_[A-Za-z0-9]+_T\\d{7})(?:\\.\\d+)?)|(?<id4>LRG_\\d+t\\d+(?:-\\d)?)|(?<id5>(?:[A-Za-z0-9][A-Za-z0-9_]+)\\.t?\\d+[a-z]?(?:\\.\\d+)?)|(?<id6>Y[A-Z]{2}\\d{3}[A-Z](?:-[A-Z])?(?:_[a-z]{1,3}RNA)?)|(?<id7>Q\\d{4}_[a-z]{1,3}RNA)|(?<id8>[A-Z]{3}\\d{1,3}(?:-\\d)?_[a-z]{1,3}RNA)|(?<id9>snR\\d+-?[A-Za-z]?_sno?RNA)|(?<id10>t[A-Z]\\([ACGUX]{3}\\)[A-Z]\\d?_tRNA))$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/ensembl/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00054"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Transcript"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "ENST00000638000",
+                            "ENST00000307864",
+                            "ENSTRUT00000006732",
+                            "ENSAMET00000021072",
+                            "ENSAZOT00000021040",
+                            "ENST00000622541",
+                            "ENST00000462612",
+                            "ENSBTAT00000072441",
+                            "ENSAZOT00000005048",
+                            "ENST00000475822"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "glytoucan": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "GlyTouCan"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>G[0-9]{5}[A-Z]{2})$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/glytoucan/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc01535"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Glycan"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "G88006IV",
+                            "G53085MI",
+                            "G17896UT",
+                            "G50341PG",
+                            "G19379ID",
+                            "G08110WX",
+                            "G70101JE",
+                            "G45504EY",
+                            "G81263BG",
+                            "G02815KT"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "go": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "Gene ontology"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^GO[:_](?<id>\\d{7})$"
+                      },
+                      "format": {
+                        "type": "string",
+                        "example": [
+                          "GO:%s",
+                          "GO_%s"
+                        ]
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://purl.obolibrary.org/obo/GO_"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00074"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Function"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "GO:0005643",
+                            "GO:0097110",
+                            "GO:0097225",
+                            "GO:0052855",
+                            "GO:2000012",
+                            "GO:0042921",
+                            "GO:0019774",
+                            "GO:0085018",
+                            "GO:0009508",
+                            "GO:0046470"
+                          ],
+                          [
+                            "GO_0005643",
+                            "GO_0097110",
+                            "GO_0097225",
+                            "GO_0052855",
+                            "GO_2000012",
+                            "GO_0042921",
+                            "GO_0019774",
+                            "GO_0085018",
+                            "GO_0009508",
+                            "GO_0046470"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "hgnc": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "HGNC"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?:(?:HGNC|hgnc):)?(?<id>\\d{1,5})$"
+                      },
+                      "format": {
+                        "type": "string",
+                        "example": [
+                          "%s",
+                          "HGNC:%s",
+                          "hgnc:%s"
+                        ]
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/hgnc/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc01774"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Gene"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "26199",
+                            "38937",
+                            "14027",
+                            "21498",
+                            "18185",
+                            "1314",
+                            "25960",
+                            "2206",
+                            "22224",
+                            "19741"
+                          ],
+                          [
+                            "HGNC:26199",
+                            "HGNC:38937",
+                            "HGNC:14027",
+                            "HGNC:21498",
+                            "HGNC:18185",
+                            "HGNC:1314",
+                            "HGNC:25960",
+                            "HGNC:2206",
+                            "HGNC:22224",
+                            "HGNC:19741"
+                          ],
+                          [
+                            "hgnc:26199",
+                            "hgnc:38937",
+                            "hgnc:14027",
+                            "hgnc:21498",
+                            "hgnc:18185",
+                            "hgnc:1314",
+                            "hgnc:25960",
+                            "hgnc:2206",
+                            "hgnc:22224",
+                            "hgnc:19741"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "hgnc_symbol": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "HGNC gene symbol"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>[A-Za-z0-9_\\-]+\\@?)$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/hgnc.symbol/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc01774"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Gene"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "MBNL2",
+                            "RGS20",
+                            "LINC02011",
+                            "IGHV1-14",
+                            "SH3RF2",
+                            "SPATA13",
+                            "HNRNPCP10",
+                            "LINC00334",
+                            "TMEM241",
+                            "RN7SL753P"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "hmdb": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "HMDB"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?:hmdb:)?(?<id>HMDB\\d+)$"
+                      },
+                      "format": {
+                        "type": "string",
+                        "example": [
+                          "%s",
+                          "hmdb:%s"
+                        ]
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/hmdb/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00909"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Compound"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "HMDB0029433",
+                            "HMDB0015609",
+                            "HMDB0000042",
+                            "HMDB0002360",
+                            "HMDB0003345",
+                            "HMDB0003550",
+                            "HMDB0036769",
+                            "HMDB0000935",
+                            "HMDB0002755",
+                            "HMDB0004369"
+                          ],
+                          [
+                            "hmdb:HMDB0029433",
+                            "hmdb:HMDB0015609",
+                            "hmdb:HMDB0000042",
+                            "hmdb:HMDB0002360",
+                            "hmdb:HMDB0003345",
+                            "hmdb:HMDB0003550",
+                            "hmdb:HMDB0036769",
+                            "hmdb:HMDB0000935",
+                            "hmdb:HMDB0002755",
+                            "hmdb:HMDB0004369"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "homologene": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "HomoloGene"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>\\d+)$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/homologene/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00101"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Ortholog"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "117",
+                            "17",
+                            "6",
+                            "142",
+                            "55",
+                            "132",
+                            "61",
+                            "109",
+                            "137",
+                            "134"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "hp": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "Human Phenotype Ontology"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^HP[:_](?<id>\\d{7})$"
+                      },
+                      "format": {
+                        "type": "string",
+                        "example": [
+                          "HP:%s",
+                          "HP_%s"
+                        ]
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://purl.obolibrary.org/obo/HP_"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc02559"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Disease"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "HP:0001947",
+                            "HP:0031592",
+                            "HP:0012085",
+                            "HP:0000956",
+                            "HP:0025238",
+                            "HP:0002861",
+                            "HP:0001680",
+                            "HP:0004417",
+                            "HP:0001701",
+                            "HP:0025084"
+                          ],
+                          [
+                            "HP_0001947",
+                            "HP_0031592",
+                            "HP_0012085",
+                            "HP_0000956",
+                            "HP_0025238",
+                            "HP_0002861",
+                            "HP_0001680",
+                            "HP_0004417",
+                            "HP_0001701",
+                            "HP_0025084"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "human_protein_atlas": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "Human Protein Atlas"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>ENSG\\d{11})$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://www.proteinatlas.org/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00905"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Protein"
+                      }
+                    }
+                  },
+                  "inchi_key": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "InChIKey"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>[A-Z]{14}\\-[A-Z]{10}(\\-[A-Z])?)$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "https://identifiers.org/inchikey/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "FIXME"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Compound"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "RYYVLZVUVIJVGH-UHFFFAOYSA-N",
+                            "RZWGTXHSYZGXKF-UHFFFAOYSA-N",
+                            "RQQIIXFYTHWFKW-ZETCQYMHSA-N",
+                            "RALAARQREFCZJO-UHFFFAOYSA-N",
+                            "HVFRJJDZWVSUIB-UHFFFAOYSA-N",
+                            "KVNZVXVZQFTXNA-UHFFFAOYSA-N",
+                            "KVQUJTYBWCGJRS-UHFFFAOYSA-N",
+                            "AFGLQVAJWVTAJT-UHFFFAOYSA-N",
+                            "LHISABQPMWXWCC-UHFFFAOYSA-N",
+                            "ZSXCHLJCWRSMMS-UHFFFAOYSA-N"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "insdc": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "GenBank/ENA/DDBJ"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?:insdc:)?(?<id>[A-Z]\\d{5}|[A-Z]{2}\\d{6}|[A-Z]{4}\\d{8}|[A-J][A-Z]{2}\\d{5}|[A-Z]{4,}\\d{9})(?:\\.\\d+)?$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/insdc/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc02567"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Gene"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "U10991",
+                            "AF116914",
+                            "AK056978",
+                            "DQ440258",
+                            "U91725",
+                            "AY301270",
+                            "U32907",
+                            "AY261360",
+                            "AK001332",
+                            "U13261"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "intact": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "IntAct"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>EBI\\-[0-9]+)$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/intact/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00507"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Interaction"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "EBI-7947422",
+                            "EBI-15714708",
+                            "EBI-16225271",
+                            "EBI-4406290",
+                            "EBI-9026465",
+                            "EBI-6403471",
+                            "EBI-1113651",
+                            "EBI-562824",
+                            "EBI-9014072",
+                            "EBI-1784742"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "interpro": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "InterPro"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>IPR\\d{6})$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/interpro/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00108"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Domain"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "IPR038152",
+                            "IPR040448",
+                            "IPR036748",
+                            "IPR034266",
+                            "IPR005479",
+                            "IPR036365",
+                            "IPR000174",
+                            "IPR001334",
+                            "IPR000731",
+                            "IPR001767"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "kegg_compound": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "KEGG Compound"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>C\\d+)$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/kegg.compound/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00814"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Compound"
+                      }
+                    }
+                  },
+                  "kegg_disease": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "KEGG Disease"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^KEGG:H(?<id>\\d+)$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/kegg.disease/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00813"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Disease"
+                      }
+                    }
+                  },
+                  "kegg_drug": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "KEGG Drug"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>D\\d+)$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/kegg.drug/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00812"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Drug"
+                      }
+                    }
+                  },
+                  "kegg_genes": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "KEGG Genes"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^\\w+:[\\w\\d\\.-]*$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/kegg.genes/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00532"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Gene, Protein"
+                      }
+                    }
+                  },
+                  "kegg_orthology": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "KEGG Orthology"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>K\\d+)$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/kegg.orthology/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00817"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Ortholog"
+                      }
+                    }
+                  },
+                  "kegg_pathway": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "KEGG Pathway"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>\\w{2,4}\\d{5})$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/kegg.pathway/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00118"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Pathway"
+                      }
+                    }
+                  },
+                  "kegg_reaction": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "KEGG Reaction"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>R\\d+)$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/kegg.reaction/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00818"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Interaction"
+                      }
+                    }
+                  },
+                  "lrg": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "LRG"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>LRG_\\d+)$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/lrg/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc02566"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Gene"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "LRG_41",
+                            "LRG_356",
+                            "LRG_147",
+                            "LRG_660",
+                            "LRG_498",
+                            "LRG_364",
+                            "LRG_203",
+                            "LRG_162",
+                            "LRG_1271",
+                            "LRG_884"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "mbgd_gene": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "MBGD gene"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>[a-z0-9]+:[A-Z0-9_\\.-]+)$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://mbgd.genome.ad.jp/rdf/resource/gene/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00130"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Gene"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "ash:AL1_RS04670",
+                            "ash:AL1_RS08245",
+                            "ash:AL1_RS02870",
+                            "ash:AL1_RS06610",
+                            "ash:AL1_RS06290",
+                            "ash:AL1_RS07260",
+                            "ash:AL1_RS08410",
+                            "ash:AL1_RS01705",
+                            "ash:AL1_RS02510",
+                            "ash:AL1_RS07245"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "mbgd_organism": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "MBGD organism"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>[a-z0-9]+)$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://mbgd.genome.ad.jp/rdf/resource/organism/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00130"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Taxonomy"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "lac",
+                            "pfl",
+                            "cou",
+                            "bvn",
+                            "btd",
+                            "ctjt",
+                            "sha",
+                            "lmoj",
+                            "dpi",
+                            "arp"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "meddra": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "MedDRA"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?:(?:MedDRA|meddra):)?(?<id>\\d+)$"
+                      },
+                      "format": {
+                        "type": "string",
+                        "example": [
+                          "%s",
+                          "MedDRA:%s",
+                          "meddra:%s"
+                        ]
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/meddra/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc02564"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Disease"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "10008033",
+                            "10027710",
+                            "10062506",
+                            "10040493",
+                            "10013611",
+                            "10065857",
+                            "10063143",
+                            "10022599",
+                            "10042342",
+                            "10047883"
+                          ],
+                          [
+                            "MedDRA:10008033",
+                            "MedDRA:10027710",
+                            "MedDRA:10062506",
+                            "MedDRA:10040493",
+                            "MedDRA:10013611",
+                            "MedDRA:10065857",
+                            "MedDRA:10063143",
+                            "MedDRA:10022599",
+                            "MedDRA:10042342",
+                            "MedDRA:10047883"
+                          ],
+                          [
+                            "meddra:10008033",
+                            "meddra:10027710",
+                            "meddra:10062506",
+                            "meddra:10040493",
+                            "meddra:10013611",
+                            "meddra:10065857",
+                            "meddra:10063143",
+                            "meddra:10022599",
+                            "meddra:10042342",
+                            "meddra:10047883"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "medgen": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "MedGen"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>CN?\\d{4,7})$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/medgen/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc02560"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Disease"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "C0264897",
+                            "C0028860",
+                            "C0018818",
+                            "C1848392",
+                            "C0006389",
+                            "C0020517",
+                            "C0000364",
+                            "CN227118",
+                            "CN203043",
+                            "CN292950"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "mesh": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "MeSH"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>[CD]\\d{6,9})$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/mesh/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00132"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Disease"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "D002065",
+                            "C562829",
+                            "C566582",
+                            "D010623",
+                            "D003327",
+                            "D001715",
+                            "D000453",
+                            "D010260",
+                            "C537322",
+                            "C563418"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "mgi": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "MGI"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?:MGI|mgi):(?<id>\\d{5,})$"
+                      },
+                      "format": {
+                        "type": "string",
+                        "example": [
+                          "MGI:%s",
+                          "mgi:%s"
+                        ]
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/mgi/MGI:"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00135"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Gene"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "MGI:2387184",
+                            "MGI:1920977",
+                            "MGI:2442415",
+                            "MGI:1098644",
+                            "MGI:1196250",
+                            "MGI:1914934",
+                            "MGI:1914238",
+                            "MGI:1919300",
+                            "MGI:1914807",
+                            "MGI:2145261"
+                          ],
+                          [
+                            "mgi:2387184",
+                            "mgi:1920977",
+                            "mgi:2442415",
+                            "mgi:1098644",
+                            "mgi:1196250",
+                            "mgi:1914934",
+                            "mgi:1914238",
+                            "mgi:1919300",
+                            "mgi:1914807",
+                            "mgi:2145261"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "mirbase": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "miRBase"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>MI\\d{7})$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/mirbase/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00136"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Transcript"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "MI0003587",
+                            "MI0000252",
+                            "MI0000811",
+                            "MI0014201",
+                            "MI0003578",
+                            "MI0000293",
+                            "MI0006384",
+                            "MI0006361",
+                            "MI0000480",
+                            "MI0006419"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "mondo": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "MONDO"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^MONDO[:_](?<id>\\d{7})$"
+                      },
+                      "format": {
+                        "type": "string",
+                        "example": [
+                          "MONDO:%s",
+                          "MONDO_%s"
+                        ]
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://purl.obolibrary.org/obo/MONDO_"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc02563"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Disease"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "MONDO:0000115",
+                            "MONDO:0002345",
+                            "MONDO:0011571",
+                            "MONDO:0020035",
+                            "MONDO:0020920",
+                            "MONDO:0004627",
+                            "MONDO:0005480",
+                            "MONDO:0010852",
+                            "MONDO:0002053",
+                            "MONDO:0015758"
+                          ],
+                          [
+                            "MONDO_0000115",
+                            "MONDO_0002345",
+                            "MONDO_0011571",
+                            "MONDO_0020035",
+                            "MONDO_0020920",
+                            "MONDO_0004627",
+                            "MONDO_0005480",
+                            "MONDO_0010852",
+                            "MONDO_0002053",
+                            "MONDO_0015758"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "nando": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "NANDO"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^NANDO[:_](?<id>\\d{7})$"
+                      },
+                      "format": {
+                        "type": "string",
+                        "example": [
+                          "NANDO:%s",
+                          "NANDO_%s"
+                        ]
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://nanbyodata.jp/ontology/NANDO_"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc02557"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Disease"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "NANDO:1200461",
+                            "NANDO:1200466",
+                            "NANDO:1200851",
+                            "NANDO:1200061",
+                            "NANDO:1200315",
+                            "NANDO:1200365",
+                            "NANDO:1200922",
+                            "NANDO:1200705",
+                            "NANDO:2200074",
+                            "NANDO:1200030"
+                          ],
+                          [
+                            "NANDO_1200461",
+                            "NANDO_1200466",
+                            "NANDO_1200851",
+                            "NANDO_1200061",
+                            "NANDO_1200315",
+                            "NANDO_1200365",
+                            "NANDO_1200922",
+                            "NANDO_1200705",
+                            "NANDO_2200074",
+                            "NANDO_1200030"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "ncbigene": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "NCBI gene"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>\\d+)$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/ncbigene/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00073"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Gene"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "63962027",
+                            "1046",
+                            "63961921",
+                            "102606930",
+                            "100472895",
+                            "407025",
+                            "84148",
+                            "88",
+                            "31157",
+                            "100463227"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "ncbiprotein": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "NCBI protein"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?:(?:\\w+\\d+(?:\\.\\d+)?)|(?:NP_\\d+))$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/ncbiprotein/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00584"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Protein"
+                      }
+                    }
+                  },
+                  "oma_group": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "OMA group"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>[A-Z]+)$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/oma.grp/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc02221"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Ortholog"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "RVAAYKY",
+                            "LFVHAIL",
+                            "EMSPITC",
+                            "NQSHFFA",
+                            "AYTHYSY",
+                            "PRPKYDP",
+                            "WSRIHIV",
+                            "DFGGWKI",
+                            "FHVAHGE",
+                            "PYVYVTH"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "oma_protein": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "OMA protein"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>[A-Z]{3}[A-Z0-9]{2}[0-9]{5,6})$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/oma.protein/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc02221"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Protein"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "ACIB400217",
+                            "ACIB400465",
+                            "HUMAN00333",
+                            "HUMAN01170",
+                            "HUMAN00470",
+                            "HUMAN03367",
+                            "ACIB400486",
+                            "HUMAN01061",
+                            "HUMAN02190",
+                            "HUMAN02112"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "omim_gene": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "OMIM gene"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?:O?MIM:)?(?<id>\\d{6})$"
+                      },
+                      "format": {
+                        "type": "string",
+                        "example": [
+                          "%s",
+                          "OMIM:%s",
+                          "MIM:%s"
+                        ]
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/mim/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00154"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Gene"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "604810",
+                            "115460",
+                            "608706",
+                            "300181",
+                            "102575",
+                            "601280",
+                            "602832",
+                            "601604",
+                            "177075",
+                            "608977"
+                          ],
+                          [
+                            "OMIM:604810",
+                            "OMIM:115460",
+                            "OMIM:608706",
+                            "OMIM:300181",
+                            "OMIM:102575",
+                            "OMIM:601280",
+                            "OMIM:602832",
+                            "OMIM:601604",
+                            "OMIM:177075",
+                            "OMIM:608977"
+                          ],
+                          [
+                            "MIM:604810",
+                            "MIM:115460",
+                            "MIM:608706",
+                            "MIM:300181",
+                            "MIM:102575",
+                            "MIM:601280",
+                            "MIM:602832",
+                            "MIM:601604",
+                            "MIM:177075",
+                            "MIM:608977"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "omim_phenotype": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "OMIM phenotype"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?:O?MIM:)?(?<id>\\d{6})$"
+                      },
+                      "format": {
+                        "type": "string",
+                        "example": [
+                          "%s",
+                          "OMIM:%s",
+                          "MIM:%s"
+                        ]
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/mim/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00154"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Disease"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "207780",
+                            "236100",
+                            "237500",
+                            "300716",
+                            "125310",
+                            "165199",
+                            "617175",
+                            "137600",
+                            "600089",
+                            "601317"
+                          ],
+                          [
+                            "OMIM:207780",
+                            "OMIM:236100",
+                            "OMIM:237500",
+                            "OMIM:300716",
+                            "OMIM:125310",
+                            "OMIM:165199",
+                            "OMIM:617175",
+                            "OMIM:137600",
+                            "OMIM:600089",
+                            "OMIM:601317"
+                          ],
+                          [
+                            "MIM:207780",
+                            "MIM:236100",
+                            "MIM:237500",
+                            "MIM:300716",
+                            "MIM:125310",
+                            "MIM:165199",
+                            "MIM:617175",
+                            "MIM:137600",
+                            "MIM:600089",
+                            "MIM:601317"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "orphanet": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "Orphanet"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?:ORPHA|ORDO|Orphanet)[:_](?<id>[A-Z0-9]+)$"
+                      },
+                      "format": {
+                        "type": "string",
+                        "example": [
+                          "ORPHA:%s",
+                          "ORDO:%s",
+                          "Orphanet:%s",
+                          "Orphanet_%s"
+                        ]
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/orphanet.ordo/Orphanet_"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc01422"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Disease"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "ORPHA:101078",
+                            "ORPHA:596",
+                            "ORPHA:1934",
+                            "ORPHA:1047",
+                            "ORPHA:60025",
+                            "ORPHA:166090",
+                            "ORPHA:275745",
+                            "ORPHA:1171",
+                            "ORPHA:93277",
+                            "ORPHA:247598"
+                          ],
+                          [
+                            "ORDO:101078",
+                            "ORDO:596",
+                            "ORDO:1934",
+                            "ORDO:1047",
+                            "ORDO:60025",
+                            "ORDO:166090",
+                            "ORDO:275745",
+                            "ORDO:1171",
+                            "ORDO:93277",
+                            "ORDO:247598"
+                          ],
+                          [
+                            "Orphanet:101078",
+                            "Orphanet:596",
+                            "Orphanet:1934",
+                            "Orphanet:1047",
+                            "Orphanet:60025",
+                            "Orphanet:166090",
+                            "Orphanet:275745",
+                            "Orphanet:1171",
+                            "Orphanet:93277",
+                            "Orphanet:247598"
+                          ],
+                          [
+                            "Orphanet_101078",
+                            "Orphanet_596",
+                            "Orphanet_1934",
+                            "Orphanet_1047",
+                            "Orphanet_60025",
+                            "Orphanet_166090",
+                            "Orphanet_275745",
+                            "Orphanet_1171",
+                            "Orphanet_93277",
+                            "Orphanet_247598"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "pdb": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "PDB"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>[0-9][A-Za-z0-9]{3})$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://rdf.wwpdb.org/pdb/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00156"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Structure"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "3PFQ",
+                            "2OUY",
+                            "6EBX",
+                            "5GHP",
+                            "6ETH",
+                            "1Y28",
+                            "6FB2",
+                            "5JO3",
+                            "2JQZ",
+                            "5L5P"
+                          ],
+                          [
+                            "3pfq",
+                            "2ouy",
+                            "6ebx",
+                            "5ghp",
+                            "6eth",
+                            "1y28",
+                            "6fb2",
+                            "5jo3",
+                            "2jqz",
+                            "5l5p"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "pfam": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "Pfam"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>PF\\d{5})$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/pfam/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00163"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Domain"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "PF03719",
+                            "PF03726",
+                            "PF02809",
+                            "PF00105",
+                            "PF00250",
+                            "PF00412",
+                            "PF01412",
+                            "PF00459",
+                            "PF02532",
+                            "PF01226"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "pubchem_compound": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "PubChem compound"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?:CID)?(?<id>\\d+)$"
+                      },
+                      "format": {
+                        "type": "string",
+                        "example": [
+                          "%s",
+                          "CID%s"
+                        ]
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/pubchem.compound/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00641"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Compound"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "9548669",
+                            "160419",
+                            "9869929",
+                            "76333303",
+                            "9868491",
+                            "27854",
+                            "76329169",
+                            "3448",
+                            "296",
+                            "10371227"
+                          ],
+                          [
+                            "CID9548669",
+                            "CID160419",
+                            "CID9869929",
+                            "CID76333303",
+                            "CID9868491",
+                            "CID27854",
+                            "CID76329169",
+                            "CID3448",
+                            "CID296",
+                            "CID10371227"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "pubchem_substance": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "PubChem substance"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?:SID)?(?<id>\\d+)$"
+                      },
+                      "format": {
+                        "type": "string",
+                        "example": [
+                          "%s",
+                          "SID%s"
+                        ]
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/pubchem.substance/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00642"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Compound"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "15229855",
+                            "15277848",
+                            "15782795",
+                            "16076657",
+                            "16035895",
+                            "12012900",
+                            "15378994",
+                            "14850434",
+                            "14847540",
+                            "15271473"
+                          ],
+                          [
+                            "SID15229855",
+                            "SID15277848",
+                            "SID15782795",
+                            "SID16076657",
+                            "SID16035895",
+                            "SID12012900",
+                            "SID15378994",
+                            "SID14850434",
+                            "SID14847540",
+                            "SID15271473"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "pubmed": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "PubMed"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?:pmid:|PMID:)?(?<id>\\d+)$"
+                      },
+                      "format": {
+                        "type": "string",
+                        "example": [
+                          "%s",
+                          "pmid:%s",
+                          "PMID:%s"
+                        ]
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/pubmed/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00179"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Literature"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "19281226",
+                            "19879151",
+                            "20858243",
+                            "10773016",
+                            "16527252",
+                            "28499733",
+                            "10397770",
+                            "15149666",
+                            "23861362",
+                            "10577920"
+                          ],
+                          [
+                            "pmid:19281226",
+                            "pmid:19879151",
+                            "pmid:20858243",
+                            "pmid:10773016",
+                            "pmid:16527252",
+                            "pmid:28499733",
+                            "pmid:10397770",
+                            "pmid:15149666",
+                            "pmid:23861362",
+                            "pmid:10577920"
+                          ],
+                          [
+                            "PMID:19281226",
+                            "PMID:19879151",
+                            "PMID:20858243",
+                            "PMID:10773016",
+                            "PMID:16527252",
+                            "PMID:28499733",
+                            "PMID:10397770",
+                            "PMID:15149666",
+                            "PMID:23861362",
+                            "PMID:10577920"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "reactome_pathway": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "Reactome pathway"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>R-[A-Z]{3}-\\d+)(?:\\.\\d+)?$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/reactome/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00185"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Pathway"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "R-HSA-165159",
+                            "R-DRE-1630316",
+                            "R-SCE-9634635",
+                            "R-DRE-140834",
+                            "R-HSA-2142753",
+                            "R-BTA-383280",
+                            "R-MMU-5218900",
+                            "R-RNO-5654219",
+                            "R-MMU-8875791",
+                            "R-MMU-9648025"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "reactome_reaction": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "Reactome reaction"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>R-[A-Z]{3}-\\d+)(?:\\.\\d+)?$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/reactome/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00185"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Reaction"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "R-DRE-1482961",
+                            "R-DRE-6814409",
+                            "R-HSA-2395869",
+                            "R-HSA-1222722",
+                            "R-HSA-893583",
+                            "R-MMU-158484",
+                            "R-HSA-8875071",
+                            "R-HSA-372519",
+                            "R-HSA-6797627",
+                            "R-DRE-975814"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "refseq_genomic": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "RefSeq genomic"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>(?:AC_|N[CGTW]_|NZ_[A-Z]+)\\d+)(?:\\.\\d+)?$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/refseq/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00187"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Gene"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "NG_004671",
+                            "NG_011844",
+                            "NG_008481",
+                            "NG_007973",
+                            "NG_001091",
+                            "NG_008005",
+                            "NG_023230",
+                            "NG_046394",
+                            "NG_009617",
+                            "NG_016421",
+                            "NG_021472"
+                          ],
+                          [
+                            "NG_004671.3",
+                            "NG_011844.2",
+                            "NG_008481.4",
+                            "NG_007973.1",
+                            "NG_001091.7",
+                            "NG_008005.1",
+                            "NG_023230.1",
+                            "NG_046394.1",
+                            "NG_009617.1",
+                            "NG_016421.2",
+                            "NG_021472.2"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "refseq_protein": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "RefSeq protein"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>[ANXYWZ]P_\\d+)(?:\\.\\d+)?$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/refseq/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00187"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Protein"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "NP_001171968",
+                            "NP_001365494",
+                            "NP_000015",
+                            "XP_011522750",
+                            "XP_011516190",
+                            "XP_005265876",
+                            "WP_016919164",
+                            "WP_080513319",
+                            "YP_001687722",
+                            "YP_001966380"
+                          ],
+                          [
+                            "NP_001171968.1",
+                            "NP_001365494.1",
+                            "NP_000015.2",
+                            "XP_011522750.1",
+                            "XP_011516190.1",
+                            "XP_005265876.1",
+                            "WP_016919164.1",
+                            "WP_080513319.1",
+                            "YP_001687722.1",
+                            "YP_001966380.1"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "refseq_rna": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "RefSeq RNA"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>(?:NM|NR|XM|XR)_\\d+)(?:\\.\\d+)?$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/refseq/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00187"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Transcript"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "XR_001747779",
+                            "XM_017013006",
+                            "NM_001199636",
+                            "XM_011532496",
+                            "NM_001110",
+                            "NR_170162",
+                            "NM_020113",
+                            "NM_001031805",
+                            "NR_027673",
+                            "XR_934019"
+                          ],
+                          [
+                            "XR_001747779.1",
+                            "XM_017013006.1",
+                            "NM_001199636.2",
+                            "XM_011532496.1",
+                            "NM_001110.4",
+                            "NR_170162.1",
+                            "NM_020113.3",
+                            "NM_001031805.1",
+                            "NR_027673.1",
+                            "XR_934019.3"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "rgd": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "RGD"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?:(?:RGD|rgd):)?(?<id>\\d{4,})$"
+                      },
+                      "format": {
+                        "type": "string",
+                        "example": [
+                          "%s",
+                          "RGD:%s",
+                          "rgd:%s"
+                        ]
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/rgd/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00188"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Gene"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "1308312",
+                            "1311120",
+                            "1309724",
+                            "1565514",
+                            "7683241",
+                            "1307957",
+                            "71036",
+                            "1307876",
+                            "1308965",
+                            "1305482"
+                          ],
+                          [
+                            "RGD:1308312",
+                            "RGD:1311120",
+                            "RGD:1309724",
+                            "RGD:1565514",
+                            "RGD:7683241",
+                            "RGD:1307957",
+                            "RGD:71036",
+                            "RGD:1307876",
+                            "RGD:1308965",
+                            "RGD:1305482"
+                          ],
+                          [
+                            "rgd:1308312",
+                            "rgd:1311120",
+                            "rgd:1309724",
+                            "rgd:1565514",
+                            "rgd:7683241",
+                            "rgd:1307957",
+                            "rgd:71036",
+                            "rgd:1307876",
+                            "rgd:1308965",
+                            "rgd:1305482"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "rhea": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "Rhea"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>\\d{5})$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/rhea/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc02083"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Reaction"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "10253",
+                            "10818",
+                            "13517",
+                            "11136",
+                            "13729",
+                            "10240",
+                            "11728",
+                            "16870",
+                            "10732",
+                            "11278"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "sra_accession": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "SRA accession"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>[SED]RA\\d+)$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/insdc.sra/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00687"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Submission"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "DRA000741",
+                            "DRA000768",
+                            "DRA001014",
+                            "DRA000833",
+                            "SRA000144",
+                            "SRA000605",
+                            "SRA008879",
+                            "ERA007227",
+                            "ERA011638",
+                            "ERA013580"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "sra_analysis": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "SRA analysis"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>[SED]RZ\\d+)$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/insdc.sra/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00687"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Analysis"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "DRZ000249",
+                            "DRZ000087",
+                            "DRZ003045",
+                            "DRZ000829",
+                            "SRZ168127",
+                            "SRZ008405",
+                            "SRZ010259",
+                            "SRZ011419",
+                            "SRZ006662",
+                            "SRZ010567"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "sra_experiment": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "SRA experiment"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>[SED]RX\\d+)$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/insdc.sra/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00687"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Experiment"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "DRX000585",
+                            "DRX000114",
+                            "DRX000613",
+                            "DRX000681",
+                            "SRX000921",
+                            "SRX000254",
+                            "SRX000626",
+                            "ERX149204",
+                            "ERX001260",
+                            "ERX000427"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "sra_project": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "SRA project"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>[SED]RP\\d+)$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/insdc.sra/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00687"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Project"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "DRP000994",
+                            "DRP000877",
+                            "DRP000649",
+                            "DRP000147",
+                            "SRP266466",
+                            "SRP297268",
+                            "SRP000065",
+                            "ERP001266",
+                            "ERP007720",
+                            "ERP104141"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "sra_run": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "SRA run"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>[SED]RR\\d+)$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/insdc.sra/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00687"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "SequenceRun"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "DRR000834",
+                            "DRR000683",
+                            "DRR000264",
+                            "DRR000453",
+                            "SRR029947",
+                            "SRR000290",
+                            "SRR004854",
+                            "ERR499402",
+                            "ERR004130",
+                            "ERR000715"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "sra_sample": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "SRA sample"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>[SED]RS\\d+)$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/insdc.sra/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00687"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Sample"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "DRS001431",
+                            "DRS001371",
+                            "DRS000894",
+                            "DRS000386",
+                            "SRS2618009",
+                            "SRS7846025",
+                            "SRS000159",
+                            "ERS452503",
+                            "ERS000126",
+                            "ERS010423"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "taxonomy": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "Taxonomy"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>\\d+)$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/taxonomy/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00700"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Taxonomy"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "1171376",
+                            "484906",
+                            "1214242",
+                            "1124991",
+                            "1037911",
+                            "1266844",
+                            "243277",
+                            "696747",
+                            "263820",
+                            "713604"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "togovar": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "TogoVar variant"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>tgv\\d+)$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://togovar.biosciencedbc.jp/variation/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc02359"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Variant"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "tgv100005930",
+                            "tgv100000890",
+                            "tgv16331",
+                            "tgv10000341",
+                            "tgv21330879",
+                            "tgv15847",
+                            "tgv1354996",
+                            "tgv100002132",
+                            "tgv16568524",
+                            "tgv62035164"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "uniprot": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "UniProt"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?:(?<id1>[A-NR-Z][0-9](?:[A-Z][A-Z0-9][A-Z0-9][0-9]){1,2}(?:-\\d+)?)|(?<id2>[OPQ][0-9][A-Z0-9][A-Z0-9][A-Z0-9][0-9](?:-\\d+)?)(?:\\.\\d+)?)$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://purl.uniprot.org/uniprot/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00221"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Protein"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "A0A174V9D2",
+                            "A0A1V4U2Y9",
+                            "Q7NXD4",
+                            "P0AAM3",
+                            "O43423",
+                            "D4IJI4",
+                            "Q66SS1",
+                            "B5IDU9",
+                            "D3TBR4",
+                            "D4ILS5"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "uniprot_mnemonic": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "UniProt mnemonic"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>[A-Z0-9]+_[A-Z0-9]{0,5})$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://purl.uniprot.org/uniprot/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc00221"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Protein"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "2ABA_ORYSJ",
+                            "33K_ADES1",
+                            "1003L_ASFK5",
+                            "1A1D_VARPS",
+                            "1B02_GORGO",
+                            "1003L_ASFP4",
+                            "1433B_MACFA",
+                            "1107L_ASFWA",
+                            "3BHS1_MOUSE",
+                            "14331_SCHMA"
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "wikipathways": {
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "example": "WikiPathways"
+                      },
+                      "regex": {
+                        "type": "string",
+                        "example": "^(?<id>WP\\d{1,5})(?:\\_r\\d+)?$"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "example": "http://identifiers.org/wikipathways/"
+                      },
+                      "catalog": {
+                        "type": "string",
+                        "example": "nbdc02116"
+                      },
+                      "category": {
+                        "type": "string",
+                        "example": "Pathway"
+                      },
+                      "examples": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          [
+                            "WP1531",
+                            "WP4312",
+                            "WP4877",
+                            "WP5020",
+                            "WP4400",
+                            "WP4474",
+                            "WP4183",
+                            "WP3650",
+                            "WP4545",
+                            "WP4462"
+                          ],
+                          [
+                            "WP1531_r107120",
+                            "WP4312_r104287",
+                            "WP4877_r116595",
+                            "WP5020_r114721",
+                            "WP4400_r108112",
+                            "WP4474_r102094",
+                            "WP4183_r106890",
+                            "WP3650_r110699",
+                            "WP4545_r116235",
+                            "WP4462_r102079"
+                          ]
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request"
+            }
+          }
+        }
+      },
+      "/config/dataset/{dataset}": {
+        "get": {
+          "tags": [
+            "config"
+          ],
+          "summary": "Get selected dataset config",
+          "operationId": "getDataset",
+          "parameters": [
+            {
+              "name": "dataset",
+              "in": "path",
+              "type": "string",
+              "description": "A key from https://github.com/dbcls/togoid-config/blob/main/config/dataset.yaml",
+              "required": true
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "successful operation",
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "label": {
+                    "type": "string",
+                    "example": "UniProt"
+                  },
+                  "regex": {
+                    "type": "string",
+                    "example": "^(?:(?<id1>[A-NR-Z][0-9](?:[A-Z][A-Z0-9][A-Z0-9][0-9]){1,2}(?:-\\d+)?)|(?<id2>[OPQ][0-9][A-Z0-9][A-Z0-9][A-Z0-9][0-9](?:-\\d+)?)(?:\\.\\d+)?)$"
+                  },
+                  "prefix": {
+                    "type": "string",
+                    "example": "http://purl.uniprot.org/uniprot/"
+                  },
+                  "catalog": {
+                    "type": "string",
+                    "example": "nbdc00221"
+                  },
+                  "category": {
+                    "type": "string",
+                    "example": "Protein"
+                  },
+                  "examples": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "example": [
+                        "A0A174V9D2",
+                        "A0A1V4U2Y9",
+                        "Q7NXD4",
+                        "P0AAM3",
+                        "O43423",
+                        "D4IJI4",
+                        "Q66SS1",
+                        "B5IDU9",
+                        "D3TBR4",
+                        "D4ILS5"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request"
+            }
+          }
+        }
+      },
+      "/config/relation": {
+        "get": {
+          "tags": [
+            "config"
+          ],
+          "summary": "Get all database relation",
+          "operationId": "getAllRelation",
+          "responses": {
+            "200": {
+              "description": "successful operation",
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "affy_probeset-ncbigene": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "detects"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is target of"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "chebi-inchi_key": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is represented as"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "represents"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "chembl_compound-chebi": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "chembl_compound-chembl_target": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "interacts with"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "interacts with"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "chembl_compound-drugbank": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "chembl_compound-hmdb": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "chembl_compound-inchi_key": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is represented as"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "represents"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "chembl_compound-mesh": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has related disease"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is related with"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "chembl_compound-pubchem_compound": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "chembl_compound-pubchem_substance": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "chembl_compound-pubmed": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has reference"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is reference of"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "chembl_target-ensembl_gene": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is product of gene"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has gene product"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "chembl_target-go": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has GO cellular component"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is GO cellular component of"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "chembl_target-interpro": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has protein domain"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is in protein"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "chembl_target-pdb": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has 3D structure"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is 3D structure of"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "chembl_target-pfam": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has protein domain"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is in protein"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "chembl_target-reactome_pathway": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "participates in pathway"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has participant molecule"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "chembl_target-uniprot": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "clinvar-medgen": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has related disease"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is related with"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "doid-mesh": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "doid-omim_phenotype": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "ensembl_gene-affy_probeset": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is target of"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "detects"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "ensembl_gene-ensembl_protein": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has gene product"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is product of gene"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "ensembl_gene-ensembl_transcript": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is transcribed to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is transcribed from"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "ensembl_gene-hgnc": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "ensembl_gene-ncbigene": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "ensembl_gene-uniprot": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has gene product"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is product of gene"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "ensembl_protein-ensembl_transcript": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is tranlated from"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is translated to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "ensembl_transcript-affy_probeset": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is target of"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "detects"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "ensembl_transcript-go": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has GO annotation"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is GO annotation of"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "ensembl_transcript-hgnc": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is transcribed from"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is transcribed to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "ensembl_transcript-refseq_rna": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "glytoucan-doid": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has related disease"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is related with"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "glytoucan-uniprot": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is attached to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is modified with"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "hgnc-ccds": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "hgnc-ec": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has EC number"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is EC number of"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "hgnc-ensembl_gene": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "hgnc-hgnc_symbol": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has synonym"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is synonym of"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "hgnc-insdc": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "hgnc-lrg": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "hgnc-mgi": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is orthologous to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is orthologous to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "hgnc-mirbase": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is transcribed to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is transcribed from"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "hgnc-ncbigene": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "hgnc-omim_gene": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "hgnc-pubmed": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has reference"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is reference of"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "hgnc-refseq_rna": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is transcribed to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is transcribed from"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "hgnc-rgd": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is orthologous to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is orthologous to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "hgnc-uniprot": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has gene product"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is product of gene"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "homologene-ncbigene": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has orthologous group member"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is member of orthologous group"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "interpro-go": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has GO annotation"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is GO annotation of"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "interpro-pdb": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is in structure"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has protein domain"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "interpro-pfam": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "interpro-pubmed": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has reference"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is reference of"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "interpro-reactome_pathway": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "participates in pathway"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has protein domain in pathway"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "interpro-uniprot": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is in protein"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has protein domain"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "mbgd_gene-uniprot": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has gene product"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is product of gene"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "mbgd_organism-taxonomy": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "medgen-hp": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "medgen-mesh": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "medgen-mondo": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "medgen-ncbigene": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is related with"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has related disease"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "medgen-omim_phenotype": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "medgen-orphanet": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "mondo-doid": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "mondo-hp": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "mondo-meddra": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "mondo-mesh": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "mondo-omim_phenotype": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "mondo-orphanet": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "nando-mondo": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "ncbigene-ensembl_gene": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "ncbigene-ensembl_protein": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has gene product"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is product of gene"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "ncbigene-ensembl_transcript": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is transcribed to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is transcribed from"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "ncbigene-go": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has GO annotation"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is GO annotation of"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "ncbigene-hgnc": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "ncbigene-mirbase": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is transcribed to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is transcribed from"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "ncbigene-omim_gene": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "ncbigene-refseq_genomic": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "ncbigene-refseq_protein": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has gene product"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is product of gene"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "ncbigene-refseq_rna": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is transcribed to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is transcribed from"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "ncbigene-taxonomy": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is gene of organism"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has gene"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "oma_protein-ensembl_gene": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is product of gene"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has gene product"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "oma_protein-ensembl_transcript": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is tranlated from"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is translated to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "oma_protein-uniprot": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "orphanet-meddra": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "orphanet-mesh": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "orphanet-omim_phenotype": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "pdb-go": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has GO annotation"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is GO annotation of"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "pdb-interpro": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has protein domain"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is in protein"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "pdb-pfam": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has protein domain"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is in protein"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "pdb-uniprot": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is 3D structure of"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has 3D structure"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "pubchem_compound-chebi": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "pubchem_compound-chembl_compound": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "pubchem_compound-drugbank": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "pubchem_compound-glytoucan": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "pubchem_compound-inchi_key": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is represented as"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "represents"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "reactome_pathway-go": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has GO biological process"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is GO biological process of"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "reactome_pathway-reactome_reaction": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has participant reaction"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "participates in pathway"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "reactome_reaction-chebi": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has participant molecule"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "participates in pathway"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "reactome_reaction-go": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has GO biological process"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is GO biological process of"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "reactome_reaction-uniprot": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has participant molecule"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "participates in pathway"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "refseq_protein-uniprot": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "refseq_rna-dbsnp": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has variant"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is located in"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "refseq_rna-hgnc": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is transcribed from"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is transcribed to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "refseq_rna-ncbigene": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is transcribed from"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is transcribed to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "refseq_rna-omim_gene": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is transcribed from"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is transcribed to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "refseq_rna-pubmed": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has reference"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is reference of"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "refseq_rna-refseq_protein": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is translated to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is tranlated from"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "refseq_rna-taxonomy": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is gene of organism"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has gene"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "rhea-chebi": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has participant molecule"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "participates in pathway"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "rhea-ec": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "rhea-reactome_reaction": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is nearly equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "sra_accession-bioproject": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "includes project"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "belongs to submission"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "sra_accession-biosample": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "includes sample"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "belongs to submission"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "sra_accession-sra_analysis": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "includes analysis"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "belongs to submission"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "sra_accession-sra_experiment": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "includes experiment"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "belongs to submission"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "sra_accession-sra_project": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "includes project"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "belongs to submission"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "sra_accession-sra_run": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "includes sequence run"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "belongs to submission"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "sra_accession-sra_sample": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "includes sample"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "belongs to submission"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "sra_experiment-bioproject": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "belongs to project"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "performs experiment"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "sra_experiment-biosample": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "captures sample"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is captured to perform experiment"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "sra_experiment-sra_project": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "belongs to project"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "performs experiment"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "sra_experiment-sra_sample": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "captures sample"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is captured to perform experiment"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "sra_project-bioproject": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "sra_run-bioproject": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "belongs to project"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "produces sequence run"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "sra_run-biosample": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is produced from sample"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is captured to produce sequence run"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "sra_run-sra_experiment": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is produced in experiment"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "produces sequence run"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "sra_run-sra_project": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "belongs to project"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "produces sequence run"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "sra_run-sra_sample": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is produced from sample"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is captured to produce sequence run"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "sra_sample-biosample": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "togovar-clinvar": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has clinical significance"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is clinical significance of"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "togovar-dbsnp": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has corresponding variant"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has corresponding variant"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "togovar-ensembl_gene": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is located in"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has variant"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "togovar-ensembl_transcript": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is located in"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has variant"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "togovar-hgnc": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is located in"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has variant"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "togovar-ncbigene": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is located in"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has variant"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "togovar-pubmed": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has reference"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is reference of"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "togovar-refseq_rna": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is located in"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has variant"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "uniprot-chembl_target": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "uniprot-dbsnp": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has variant"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is located in"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "uniprot-ec": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has EC number"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is EC number of"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "uniprot-ensembl_gene": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is product of gene"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has gene product"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "uniprot-ensembl_protein": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "uniprot-ensembl_transcript": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is tranlated from"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is translated to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "uniprot-go": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has GO annotation"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is GO annotation of"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "uniprot-hgnc": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is product of gene"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has gene product"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "uniprot-insdc": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is product of gene"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has gene product"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "uniprot-intact": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "participates in pathway"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has participant molecule"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "uniprot-ncbigene": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is product of gene"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has gene product"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "uniprot-oma_group": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is member of orthologous group"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has orthologous group member"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "uniprot-omim_gene": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is product of gene"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has gene product"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "uniprot-omim_phenotype": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has related disease"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is related with"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "uniprot-orphanet": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has related disease"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is related with"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "uniprot-pdb": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has 3D structure"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is 3D structure of"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "uniprot-pfam": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has protein domain"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is in protein"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "uniprot-reactome_pathway": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "participates in pathway"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has participant molecule"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "uniprot-refseq_protein": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is equivalent to"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is equivalent to"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "uniprot-uniprot_mnemonic": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has synonym"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is synonym of"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "wikipathways-chebi": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has participant molecule"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "participates in pathway"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "wikipathways-doid": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has related disease"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "is related with"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "wikipathways-uniprot": {
+                    "properties": {
+                      "link": {
+                        "type": "object",
+                        "properties": {
+                          "forward": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "has participant molecule"
+                              }
+                            }
+                          },
+                          "reverse": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "example": "participates in pathway"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request"
+            }
+          }
+        }
+      },
+      "/config/relation/{source}-{target}": {
+        "get": {
+          "tags": [
+            "config"
+          ],
+          "summary": "Get selected database relation",
+          "operationId": "getRelation",
+          "parameters": [
+            {
+              "name": "source",
+              "in": "path",
+              "type": "string",
+              "description": "A key from https://github.com/dbcls/togoid-config/blob/main/config/dataset.yaml",
+              "required": true
+            },
+            {
+              "name": "target",
+              "in": "path",
+              "type": "string",
+              "description": "A key from https://github.com/dbcls/togoid-config/blob/main/config/dataset.yaml",
+              "required": true
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "successful operation",
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "link": {
+                    "type": "object",
+                    "properties": {
+                      "forward": {
+                        "type": "object",
+                        "properties": {
+                          "label": {
+                            "type": "string",
+                            "example": "is attached to"
+                          }
+                        }
+                      },
+                      "reverse": {
+                        "type": "object",
+                        "properties": {
+                          "label": {
+                            "type": "string",
+                            "example": "is modified with"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request"
+            }
+          }
+        }
+      },
+      "/config/descriptions": {
+        "get": {
+          "tags": [
+            "config"
+          ],
+          "summary": "Get database description",
+          "operationId": "getDescription",
+          "responses": {
+            "200": {
+              "description": "successful operation",
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "bioproject": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "BioProject is a database which collects the results of research projects under the umbrella of the project or initiative. The database consists of tables of projects, which users can search or browse to find all data outputs related to that project. Users can submit projects or download data via FTP."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "特定の組織やコンソーシアムにより立ち上げられたゲノムプロジェクトをはじめとする生命科学分野の各種プロジェクトを単位とし、そこから産生されたデータセットをまとめたデータベースです。産生された配列データに関しては完全決定配列（ドラフト、進行中を含む）、アセンブリ、アノテーション、マッピングなどの進捗状況が含まれています。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "BioProject (Formerly Genome Project)"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      }
+                    }
+                  },
+                  "biosample": {
+                    "type": "object"
+                  },
+                  "ccds": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "This database seeks to identify a core set of human and mouse protein coding regions of high quality that are consistently annotated."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "高品質で確実にアノテーション付けされたヒトとマウスのタンパク質コード領域のコアセットを集約し、提供しているデータベースです。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "CCDS"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      }
+                    }
+                  },
+                  "chebi": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "ChEBI is a collection of data on entities of biological interest.\nThis database concentrates on assembling data on smaller chemical compounds, such as atoms, molecules, ions, radicals etc. These should be produced in nature or be synthetic molecules affecting biological processes in living organisms.\nChEBI does not generally include molecules directly encoded by the genome.\nThe database contains 31,651 entries with annotations.\nA keyword search option is available.\nIn addition to this an advanced search option, which includes a structure drawing tool, is provided.\nThe ChEBI database can be searched individually or in combination with other databases."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "生命プロセスに介在する小分子化合物の辞典です。ゲノムに直接コード化されている分子（例：核酸、タンパク、ペプチド）はこのデータベースの対象外です。登録されているデータは、多数の情報源のデータを組み合わせ、冗長性を除いています。主な情報源はIntEnz(EBI)、KEGG COMPOUND、PDBeChem(EBI)、ChEMBL(EBI)です。 ChEBIオントロジー（化合物オントロジー）による分類情報と階層表示が特徴です。\n全てのエントリーにはデータの信頼性を示す★印がついています； 3つ星：ChEBIチームが手作業で注釈付けを行ったもの。2つ星：ChEMBLチームまたはデータ提供者が手作業で注釈付けを行ったもの。1つ星：情報源から自動的に取得した仮エントリーで、手作業での注釈付けが行われていないもの。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "ChEBI"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "European Bioinformatics Institute"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "European Bioinformatics Institute"
+                      }
+                    }
+                  },
+                  "chembl_compound": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "ChEMBL is a database for bioactive molecules. It collects information of small molecules, such as calculated properties (e.g. logP, Molecular Weight, Lipinski Parameters, etc.) and abstracted bioactivities (e.g. binding constants, pharmacology and ADMET data), and the target information. Metadata of assays for small molecule activities or assays for binding activities between small molecules and its targets are also provided."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "ChEMBLは創薬を目的とした生理活性をもつ化合物や小分子のデータベースです。化合物、核酸などの小分子と、そのターゲットやアッセイ情報を紐付けて収載しています。化合物や小分子の名称、分子式、分子量、標準SMILES、標準InChIなどの情報に加え、結合定数、ADMEデータなど生理活性に関する情報や、薬としての開発段階の情報などが付与されています。化合物を名称や構造で検索したり、ターゲットをタンパク質の名称で検索することができます。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "ChEMBL"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "EMBL-EBI"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "EMBL-EBI"
+                      }
+                    }
+                  },
+                  "chembl_target": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "ChEMBL is a database for bioactive molecules. It collects information of small molecules, such as calculated properties (e.g. logP, Molecular Weight, Lipinski Parameters, etc.) and abstracted bioactivities (e.g. binding constants, pharmacology and ADMET data), and the target information. Metadata of assays for small molecule activities or assays for binding activities between small molecules and its targets are also provided."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "ChEMBLは創薬を目的とした生理活性をもつ化合物や小分子のデータベースです。化合物、核酸などの小分子と、そのターゲットやアッセイ情報を紐付けて収載しています。化合物や小分子の名称、分子式、分子量、標準SMILES、標準InChIなどの情報に加え、結合定数、ADMEデータなど生理活性に関する情報や、薬としての開発段階の情報などが付与されています。化合物を名称や構造で検索したり、ターゲットをタンパク質の名称で検索することができます。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "ChEMBL"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "EMBL-EBI"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "EMBL-EBI"
+                      }
+                    }
+                  },
+                  "civic_gene": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "CIViC is a knowledgebase for Clinical Interpretation of Variants in Cancer. It has collected knowledge of the therapeutic, prognostic, diagnostic and predisposing relevance of inherited and somatic variants in cancer based on expert-crowdsourcing."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "CIViCは癌におけるバリアントの臨床的解釈のための知識ベースです。遺伝性および体細胞性の全てのタイプの癌におけるバリアント情報と、その治療、予後、診断、素因への関連性を、専門家によるクラウドソーシングの形式で収集しています。バリアント、遺伝子、疾患、薬、evidence情報が整理されています。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "CIVIC"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "The McDonnell Genome Institute, Washington University School of Medicine"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "The McDonnell Genome Institute, Washington University School of Medicine"
+                      }
+                    }
+                  },
+                  "clinvar": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "ClinVar is a freely available archive describing relationships between medically important variants and phenotypes. Submissions report human variation, interpretations of the relationship of that variation to human health, and the evidence supporting each interpretation. ClinVar is tightly coupled with dbSNP and dbVar, which maintain information about locations of variations on human assemblies, and also based on the phenotypic descriptions maintained in MedGen (http://www.ncbi.nlm.nih.gov/medgen). Each record contains the submitter, the variation and the phenotype. Furthermore, to facilitate evaluation of the medical importance of each variant, ClinVar aggregates submissions with the same variation/phenotype combination, adds value from other NCBI databases, and reports if there are conflicting clinical interpretations. Data in ClinVar are available in multiple formats, including html, download as XML, VCF or tab-delimited subsets."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "ヒトゲノムの多様性と関連する疾患についての情報を収集し、自由に利用できるアーカイブとして提供しているデータベースです。多型の位置、遺伝子名、疾患との関わりなどを収録しています。遺伝子情報はNCBIのdbSNPおよびdbVarと、表現型に関してはMedGenとリンクしています。また、NIH Genetic Testing Registry (GTR)、OMIM、PubMedからも情報を収集しています。各データはhtml形式での閲覧の他、XMLやタブ区切り形式、一部データはVCFファイルでダウンロードできます。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "ClinVar"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      }
+                    }
+                  },
+                  "dbsnp": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "dbSNP collects information on polymorphisms based on single and small-scale multi-base substitutions, including insertions and deletions, microsatelites, and non-polymorphic variants. Differences in the frequency of polymorphisms in a population can be visually compared for each SNP."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "1～数塩基の置換、挿入/欠失、反復等の多型情報からなるデータベースです。各SNPについて、集団間での多型頻度の違いを視覚的に比較することもできます。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "dbSNP"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      }
+                    }
+                  },
+                  "dgidb": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "DGIdb is a database about drug-gene interactions and the druggable genome. It collects and integrates drug-gene interactions and gene druggability information from papers, databases and web resources, such as DrugBank, PharmGKB, ChEMBL, Drug Target Commons, TTD, and others, using a combination of expert curation and text-mining. It consists of gene records for gene details, drug records for drug details and Interaction records for interaction of the genes and drugs. Users can enter a list of genes to retrieve all known or potentially druggable genes in that list. Results can be filtered by source, interaction type, or gene category."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "DGIdbは薬物と遺伝子の相互作用および創薬可能なゲノム資源に関するデータベースです。 DrugBank、PharmGKB、Chembl、Drug Target Commons、TTDなど、様々な論文、データベース、その他のWebリソースから、薬物と遺伝子の相互作用および遺伝子の創薬への適用可能性情報を専門家によるキュレーションとテキストマイニングにより整理・統合して提供しています。 薬に関するレコード、遺伝子に関するレコード、相互作用に関するレコードに分かれて整理されており、相互に参照できます。すべてのデータは、無料でダウンロードするか（＊ダウンロードページに条件が記載されている場合を除く）、APIを介してアクセスできます。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "DGiDB"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "McDonnell Genome Institute, Washington University School of Medicine"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "McDonnell Genome Institute, Washington University School of Medicine"
+                      }
+                    }
+                  },
+                  "doid": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "This site provides a Disease Ontology, which is a standardized ontology organized by human disease terms and related medical concepts. The DO terms are associated with MeSH, ICD, NCI's thesaurus, SNOMED and OMIM to integrate disease and medical vocabularies."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "ヒトの疾患に関する用語や概念について整理したDisease Ontologyを提供するサイトです。MeSH、ICD、NCI’s thesaurus、SNOMEDやOMIMへリンク付けられています。キーワードで語彙を検索することができます。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "DO"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "Institute of Genome Sciences, University of Maryland School of Medicine"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "Institute of Genome Sciences, University of Maryland School of Medicine"
+                      }
+                    }
+                  },
+                  "drugbank": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "DrugBank is a database of detailed informatics resources on approved and experimental drugs. The database contains informaiton on drug targets as well as the results of experiments resulting in extensive bioinformatics and chemoinformatics data. Users can browse or search by drug or target. Data is available for download."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "薬剤の化学的、薬理的、薬事的データとそのターゲット（配列、構造、パスウエイ）の詳細情報を収集、統合したバイオインフォマティクスおよびケモインフォマティクスのリソースです。薬剤エントリー約4,800件のうち、FDA承認小分子薬剤が1,350以上、FDA承認バイオテク（タンパク/ペプチド）薬剤123件、栄養補助食品71件、実験的薬剤が3,243件以上が含まれています。2,500以上の非冗長タンパク配列がFDA承認薬剤エントリーにリンクしています。各エントリーにつき100以上のデータ項目が存在します。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "DrugBank"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "University of Alberta/Department of Computing Science"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "University of Alberta/Department of Computing Science"
+                      }
+                    }
+                  },
+                  "ec": {
+                    "type": "object"
+                  },
+                  "ena": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "ENA is a database of data from global nucleotide sequencing projects. The database contains information on projects from raw phases trhough complete functional annotation. Users can search by keyword or DNA sequence. Bulk data is available for download."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "次世代シーケンサーによる配列データのレポジトリサイトです。サンプル、実験情報、機器情報、データとしては配列トレース、配列、クオリティ値を含み、アセンブル、マッピング、機能アノテーションも提供しています。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "ENA"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "European Bioinformatics Institute"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "European Bioinformatics Institute"
+                      }
+                    }
+                  },
+                  "ensembl_gene": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "ENSEMBL is a collection of automatically annotated genome databases for vertebrates and a number of eukaryotes, integrated with all other relevant biological data available.\r\nThe repository covers data on gene annotation, microarray probeset mapping and comparative genomics among many other topics.\r\nInformation may be downloaded by a variety of means: \r\nFor small amounts of data, an export option is suggested.\r\nFor larger amounts of data, an FTP site is provided from where a complete database may be downloaded in one of various formats, from flat files to MySQL dumps."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "ゲノム解読された脊椎生物およびその他の主要な真核生物を対象として自動アノテーションを行い、その結果をゲノムビューワやデータベースとして公開しているプロジェクトです。EMBL-EBIとSanger Centreが共同で進めています。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "Ensembl"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "Wellcome Trust Sanger Institute"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "Wellcome Trust Sanger Institute"
+                      }
+                    }
+                  },
+                  "ensembl_protein": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "ENSEMBL is a collection of automatically annotated genome databases for vertebrates and a number of eukaryotes, integrated with all other relevant biological data available.\r\nThe repository covers data on gene annotation, microarray probeset mapping and comparative genomics among many other topics.\r\nInformation may be downloaded by a variety of means: \r\nFor small amounts of data, an export option is suggested.\r\nFor larger amounts of data, an FTP site is provided from where a complete database may be downloaded in one of various formats, from flat files to MySQL dumps."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "ゲノム解読された脊椎生物およびその他の主要な真核生物を対象として自動アノテーションを行い、その結果をゲノムビューワやデータベースとして公開しているプロジェクトです。EMBL-EBIとSanger Centreが共同で進めています。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "Ensembl"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "Wellcome Trust Sanger Institute"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "Wellcome Trust Sanger Institute"
+                      }
+                    }
+                  },
+                  "ensembl_transcript": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "ENSEMBL is a collection of automatically annotated genome databases for vertebrates and a number of eukaryotes, integrated with all other relevant biological data available.\r\nThe repository covers data on gene annotation, microarray probeset mapping and comparative genomics among many other topics.\r\nInformation may be downloaded by a variety of means: \r\nFor small amounts of data, an export option is suggested.\r\nFor larger amounts of data, an FTP site is provided from where a complete database may be downloaded in one of various formats, from flat files to MySQL dumps."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "ゲノム解読された脊椎生物およびその他の主要な真核生物を対象として自動アノテーションを行い、その結果をゲノムビューワやデータベースとして公開しているプロジェクトです。EMBL-EBIとSanger Centreが共同で進めています。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "Ensembl"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "Wellcome Trust Sanger Institute"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "Wellcome Trust Sanger Institute"
+                      }
+                    }
+                  },
+                  "glytoucan": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "GlyTouCan is an international repository of glycan structures. This database contains uncurated glycan structures ranging in resolution from monosaccharide composition to fully defined structures, as long as there are no inconsistencies in the structure. The database allows users to search by text, graphic input or motif, and browse using motif-list or glycan-list."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "糖鎖構造データを収録した国際糖鎖構造リポジトリです。単糖類組成からグリコシド結合形状などの明確な構造まで、構造に不一致がない限り世界的にユニークなアクセッション番号を付けて登録することができます。キーワード、モチーフ、糖鎖構造画像からの検索、モチーフや糖鎖のリストからのブラウズが可能です。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "GlyTouCan"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "GlyTouCan Project Team"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "GlyTouCan Project Team"
+                      }
+                    }
+                  },
+                  "go": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "GO is a database which provides a controlled vocabulary of terms for describing gene product characteristics and gene product annotation data. It contains data of terms, definitions and ontology structure. The most recent version of the ontology and the annotation files contributed by members of the GO Consortium are available for download. The GO provides the AmiGO browser and search engine which are web browser-based access to the GO database."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "遺伝子オントロジー（Gene Ontology;GO）とは、生物学的概念を記述するための標準となる語彙を策定しようとするプロジェクトです。GOで定義された用語はGO Termと呼ばれ、Cellular component、Biological process、Molecular functionという3つのカテゴリーに分類されています。GOのデータは、非循環有向グラフ (Directed Acyclic Graph: DAG) と呼ばれるデータ構造を用いて計算機上で記述することができます。\nこのサイトでは、GO Termや関連ツールの配布を行っています。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "GO"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "The GO Consortium"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "The GO Consortium"
+                      }
+                    }
+                  },
+                  "hgnc": {
+                    "type": "object"
+                  },
+                  "hgnc_symbol": {
+                    "type": "object"
+                  },
+                  "hmdb": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "HUMDB is a database of human metabolites. The database contains information on thousands of metabolites produced by and found in the human body as a result of metabolic processes. genes and proteins related to the metabolites are also affiliated with records, where appropriate. Data on metabolites and the associated genes and proteins are available for download."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "ヒト体内における低分子代謝物の詳細情報を収集したデータベースです。メタボロミクスや臨床化学、バイオマーカー探索、教育分野で活用されることを目的に構築しており、化学データ、臨床データ、分子生物学/化学データを含んでいます。現在、7,900代謝物が登録されており、7,200のタンパク質（DNA）配列のリンク情報があります。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "HMDB"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "University of Alberta"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "University of Alberta"
+                      }
+                    }
+                  },
+                  "homologene": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "In Homologenes, users can find automatically constructed homologous gene sets from the full-length genome sequences of a wide range of eukaryotic species, as well as mRNA and protein sequences."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "全ゲノム配列が決定された20種類の真核生物の間で自動的検出したホモログ遺伝子のセット、およびmRNAやタンパク質の配列データを提供しています。他の生物種のUniGene配列でホモログの可能性があるものも表示されます。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "HomoloGene"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      }
+                    }
+                  },
+                  "hp": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "The Human Phenotype Ontology (HPO) provides a standardized vocabulary of phenotype specialized in human disease. The medical literatures, Orphanet, DECIPHER, and OMIM are used for developing the HPO."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "The Human Phenotype Ontology (HPO) はヒトの疾患に関連する形質の標準化された語彙を提供しています。医学論文、Orphanet、DECIPHER,やOMIMを基に開発されており、疾患と関連する形質の語彙や、疾患に関連する遺伝子情報が収載されています。疾患名、形質、遺伝子名で検索することができます。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "HPO"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "The Jackson Laboratory"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "The Jackson Laboratory"
+                      }
+                    }
+                  },
+                  "human_protein_atlas": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "Human Protein Atlas is a database of protein expression and localization. The database contains information on where proteins localize within cells and lists antibodies for the detection of human proteins. Information on expression in cancer lines as well as RNA transcript expression is also represented. Elements can be searched by several positional characteristics."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "様々な種類のヒトの器官、組織、細胞におけるタンパク質の発現および局在に関するデータベースです。蛍光抗体イメージング、質量分析に基づくプロテオミクス、網羅的な遺伝子発現解析によるトランスクリプトミクスおよびシステム生物学の手法により得られた情報を遺伝子ごとに記載しています。各レコードは３つのアトラスで構成されています。\n「組織アトラス」：ヒトの主要組織や器官におけるRNA発現量、タンパク質発現量\n「細胞アトラス」：RNA発現量や発現画像、GFP発現画像など細胞内での局在\n「疾病アトラス」：生存がん患者の組織における量的発現解析（RNA-seq）や空間的発現解析（マイクロアレイ）によるタンパク質発現レベル\nまた、抗体の情報、細胞内器官の説明、各組織における腫瘍の説明や生存率の情報なども収録しています。\n遺伝子名、抗体名、タンパク質の分類によるデータの絞り込みが可能です。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "Human Protein Atlas"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "Uppsala University"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "Uppsala University"
+                      }
+                    }
+                  },
+                  "inchi_key": {
+                    "type": "object"
+                  },
+                  "insdc": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "It is a portal site for the INSDC(International Nucleotide Sequence Database Collaboration), which is an initiative operated between DDBJ, EMBL-EBI and NCBI.  Each organization operates DNA databases in close coordination and cooperation with each other to achieve common accession numbers, and standardize data format (INSD-XML). The databases are called the International Nucleotide Sequence Databases (INSD)."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "本サイトは、３大DNAデータベースであるDDBJ、ENA(European Nucleotide Archive)、 NCBIの協力で運営されるINSDC(International Nucleotide Sequence Database Collaboration)のポータルサイトです。INSDCは連携して塩基配列のアクセションIDの共通化やデータ形式の統一(INSD-XML)などに取り組みながら、個々の拠点におけるWebサービスの開発が行われています。INSDCが連携して構築・運営しているデータベースは国際塩基配列データベース (International Nucleotide Sequence Databases, INSD) と呼ばれます。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "INSDC"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "European Bioinformatics Institute (EMBL-EBI)"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "European Bioinformatics Institute (EMBL-EBI)"
+                      }
+                    }
+                  },
+                  "intact": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "IntAct is a database of molecular interactions. The database contains information on more than 400,000 interactions gathered from primary literature. Users can search by gene, protein, or publication, among others, and the database includes manually annotated data from several other interaction databases. Software and bulk data, updoated weekly, are also available for download."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "IntActはオープンソースの分子間相互作用のデータベースとツールキットで構成されています。データは文献から取得したり、専門家によって蓄積されたデータから構成されています。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "IntAct"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "European Bioinformatics Institute"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "European Bioinformatics Institute"
+                      }
+                    }
+                  },
+                  "interpro": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "InterPro is a database that analyses proteins functionally and classifies them into families as well as predicts their domain and sites in the genome.\nThis repository harvests its content from a large number of related databases and consolidates its findings into a single searchable resource avoiding the occurrence of redundant entries.\nInterPro aims to update their content every 8 weeks.\nA keyword search is available and an option is provided where a protein sequence can be entered for analysis."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "EBI によるタンパク質のファミリー分類、ドメイン、機能サイトに関する記述を収集した統合データベースです。UniProtやPROSITE、PANTHER、ProDom、SMARTなどタンパク質の特性を収録している複数のデータベースを集結し、様々なレベルでのタンパク質の特徴を提供しています。InterProScanを用いて、ユーザが入力した配列から機能ドメインや構造ドメインを検索することができます。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "InterPro"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "European Bioinformatics Institute"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "European Bioinformatics Institute"
+                      }
+                    }
+                  },
+                  "kegg_compound": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "KEGG COMPOUND is a database of biologically relevant compounds, including chemical structures and associated information for compounds in the KEGG database such as small molecules, biopolymers, and other related substances. The site also has a collection of links to other relevant KEGG resources such as GLYCAN."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "KEGG COMPOUNDは、小分子、生体高分子、および生体関連化学物質のデータベースです。 各エントリーはC番号とよばれるアクセッション番号で識別され、化学構造や関連する生体反応、パスウエイ、他のデータベースとのリンク情報が含まれています。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "KEGG COMPOUND"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "Kyoto University Institute for Chemical Research Bioinformatics Center"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "京都大学　化学研究所　附属バイオインフォマティクスセンター"
+                      }
+                    }
+                  },
+                  "kegg_disease": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "KEGG DISEASE is a database of human diseases with information on perturbed molecular networks. Each disease entry contains a list of known disease genes, environmental factors (carcinogens, pathogens, etc), diagnostic markers and therapeutic drugs with reference information. This database provides maps of molecular networks associated with diseases through links to the KEGG PATHWAY database. Users can search human diseases by names, description, categories, pathways, and known causative genes."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "KEGG DISEASEは、遺伝要因が既知の疾患（単一遺伝子疾患及び多因子性疾患）と病原体ゲノムが既知の感染症疾患に関する情報を、計算処理が可能な形に集約したデータベースです。各疾患エントリは H番号とよばれるアクセッション番号で識別され、関連するパスウエイ、病因遺伝子のリスト、ならびに環境要因、診断マーカー、治療薬などの分子のリストで表現されています。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "KEGG DISEASE"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "Kyoto University Institute for Chemical Research Bioinformatics Center"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "京都大学　化学研究所　附属バイオインフォマティクスセンター"
+                      }
+                    }
+                  },
+                  "kegg_drug": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "KEGG DRUG is a comprehensive database of drug information about all marketed drugs in Japan, as well as many prescription drugs in USA and Europe. KEGG DRUG is based on chemical structure or component, and each entry contains information about drug targets (pathways), metabolizing enzymes and other interacting molecules. This database also includes crude drugs and TCM (Tradictional Chinese Medicine). Users can check for drug-drug interaction, view structure maps representing the history of drug development and search drugs by generic names, trade names, and components."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "KEGG DRUG は、日本、米国、欧州の医薬品情報を、化学構造と成分の観点から一元的に集約・管理したデータベースです。とくに日本の医薬品は医療用（処方薬）だけでなく一般用（大衆薬、OTC薬）もすべて網羅し、個々の製品情報（添付文書情報）へのリンクがつけられています。また化学薬品だけでなく、生薬・漢方方剤もデータベース化されています。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "KEGG DRUG"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "Kyoto University Institute for Chemical Research Bioinformatics Center"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "京都大学　化学研究所　附属バイオインフォマティクスセンター"
+                      }
+                    }
+                  },
+                  "kegg_genes": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "KEGG geneS is a catalog of gene information for multiple species with species-specified gene information for all species with complete genome sequences. The database references primary sources and provides pathway, ortholog, paralog, and motif searching functions. Results of gene searches include nucleotide and protein information."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "KEGG GENESは、全ゲノム配列が決定された生物種について、その遺伝子セットをRefSeq その他の公共データベースから自動生成し、KEGG 独自のアノテーション（KO アノテーション）を行っているデータベースです。\n以前、VGENES (http://integbio.jp/dbcatalog/record/nbdc00820) や VGENOME (http://integbio.jp/dbcatalog/record/nbdc00821) に収録されていたウィルスに関する情報も収録されています。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "KEGG GENES Database"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "Kyoto University Institute for Chemical Research Bioinformatics Center"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "京都大学　化学研究所　附属バイオインフォマティクスセンター"
+                      }
+                    }
+                  },
+                  "kegg_orthology": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "KEGG ORTHOLOGY is a database of KEGG pathway ortholog groups, and contains the pathways at the core of the KEGG representation system. Users can search for ortholog groups and explore members across species."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "KEGG ORTHOLOGYは、KEGGパスウェイの各ノードまたはBRITE機能階層の最下層ノードに対応したオーソロググループを手作業で定義したものです。ゲノム中の各遺伝子にKO識別子（K番号）を付与することで、KEGGパスウェイやBRITE機能階層へのマッピング（エンリッチメント）が可能となります。KOシステムは、ゲノムの情報からパスウェイ等高次生命システム情報を解読するための架け橋となります。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "KEGG ORTHOLOGY (KO) Database"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "Kyoto University Institute for Chemical Research Bioinformatics Center"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "京都大学　化学研究所　附属バイオインフォマティクスセンター"
+                      }
+                    }
+                  },
+                  "kegg_pathway": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "The KEGG PATHWAY database has manually drawn pathway maps that represent molecular interaction and reaction networks for the following: Global Map, Metabolism, genetic Information Processing, Cellular Processes, Organismal Systems, Human Diseases and also structure relationships in Drug Development. By using KEGG PATHWAY mapping, molecular datasets can be mapped for the biological interpretation of higher-level systemic functions."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "代謝、様々な細胞プロセス、ヒト疾患などに関する分子ネットワークの知識を表現したパスウェイマップを収録しています。マップは文献等から手作業で作成しています。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "KEGG PATHWAY Database"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "Kyoto University Institute for Chemical Research Bioinformatics Center"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "京都大学　化学研究所　附属バイオインフォマティクスセンター"
+                      }
+                    }
+                  },
+                  "kegg_reaction": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "KEGG REACTION is a database of enzymatic reactions. The database contains all KEGG enzyme interactions and KEGG pathway metabolic reactions, including related pathways, and uses IUBMB nomenclature. Users can also find the reaction pathway of individual enzymes."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "KEGG REACTIONは、KEGG ENZYMEに格納されているすべての反応と、KEGG PATHWAYの代謝パスウエイの反応を蓄積したデータベースです。 各反応はR番号によって識別され、 反応の構造式や関連する酵素のオーソロググループが収集されており、ゲノム(酵素遺伝子)情報と化学(化合物のペア)情報の統合解析を可能としています。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "KEGG REACTION"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "Kyoto University Institute for Chemical Research Bioinformatics Center"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "京都大学　化学研究所　附属バイオインフォマティクスセンター"
+                      }
+                    }
+                  },
+                  "lrg": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "LRG is a database of stable genomic, transcript and protein reference sequences for reporting clinically relevant sequence variants. NCBI (RefSeq) and EMBL-EBI (Ensembl/GENCODE) are working together to rationalise differences in their gene sets. Records contain information about genomic, transcript and protein sequences, annotations, maps about the genome assembly, etc. This database allows users to search using LRG identifier, HGNC gene name, NCBI and Ensembl accession numbers (gene or transcript), gene synonym or LRG status (public or pending). Genome browsers on Ensembl, NCBI and UCSC are available."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "ゲノム、転写産物、タンパク質のリファレンス配列のデータベースです。臨床に関連する変異配列を報告するためのリファレンス配列を、 NCBI（RefSeq）とEMBL-EBI（Ensembl / GENCODE）の協力により情報統合しています。 各レコードには、ゲノム、転写産物、タンパク質の配列、アノテーション、ゲノムアセンブリに関するマップなどが含まれています。LRG番号、HGNC遺伝子名、NCBIやEnsemblのID番号（遺伝子、転写産物）、遺伝子の同義語、公開非公開の別による絞り込みが可能です。また、Ensembl、NCBI、UCSCのゲノムブラウザが利用可能です。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "LRG"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "European Bioinformatics Institute (EMBL-EBI)"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "European Bioinformatics Institute (EMBL-EBI)"
+                      }
+                    }
+                  },
+                  "mbgd_gene": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "MBGD is a database with a workbench system for comparative analysis of completely sequenced microbial genomes, mainly for creating orthologous or homologous gene cluster tables. MBGD classifies genomes by the hierarchical clustering method known as UPGMA, using precomputed similarity relationships identified by all-against-all BLAST search. Users can change the set of organisms or cutoff parameters to create their own orthologous groupings. Thus comparative genomics is facilitated from various points of view such as ortholog identification, paralog clustering, motif analysis and gene order comparison."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "オーソログ解析に基づいて微生物ゲノムの比較解析を行うためのデータベースです。公開されたゲノム全体を含む標準オーソログテーブルに基づいて、各オーソロググループの系統プロファイルの比較などを行えるほか、動的なオーソログ解析機能によって、利用者自身が持つゲノム配列も含めて、興味のある生物種セットに対象を絞った比較を行うこともできます。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "MBGD"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "National Institute for Basic Biology"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "自然科学研究機構　基礎生物学研究所"
+                      }
+                    }
+                  },
+                  "mbgd_organism": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "MBGD is a database with a workbench system for comparative analysis of completely sequenced microbial genomes, mainly for creating orthologous or homologous gene cluster tables. MBGD classifies genomes by the hierarchical clustering method known as UPGMA, using precomputed similarity relationships identified by all-against-all BLAST search. Users can change the set of organisms or cutoff parameters to create their own orthologous groupings. Thus comparative genomics is facilitated from various points of view such as ortholog identification, paralog clustering, motif analysis and gene order comparison."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "オーソログ解析に基づいて微生物ゲノムの比較解析を行うためのデータベースです。公開されたゲノム全体を含む標準オーソログテーブルに基づいて、各オーソロググループの系統プロファイルの比較などを行えるほか、動的なオーソログ解析機能によって、利用者自身が持つゲノム配列も含めて、興味のある生物種セットに対象を絞った比較を行うこともできます。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "MBGD"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "National Institute for Basic Biology"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "自然科学研究機構　基礎生物学研究所"
+                      }
+                    }
+                  },
+                  "meddra": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "MedDRA is a standardized medical terminology for regulatory information of medical products. It is available for use in the registration, documentation and safety monitoring of medical products. It is provided in many languages, which are Chinese, Czech, Dutch, French, German, Hungarian, Italian, Japanese, Korean, Portuguese, Portuguese - Brazilian, Russian, and Spanish in addition to English Master."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "MedDRAは人間が使用する医薬品の規制情報を国際的に共有しやすくするために作成された、標準化された国際医療用語集です。英語版の他に、中国語、チェコ語、オランダ語、フランス語、ドイツ語、ハンガリー語、イタリア語、日本語、韓国語、ポルトガル語、ポルトガル語（ブラジル語）、ロシア語、スペイン語で提供されています。英国の医薬品医療製品規制庁（MHRA）に属する用語に基づいて、WHOを含むICHパートナーによって開発されました。サブスクリプションレベルにより有償・無償が異なります。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "MedDRA"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "The International Council for Harmonisation of Technical Requirements for Pharmaceuticals for Human Use (ICH)"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "医薬品規制調和国際会議（ICH）"
+                      }
+                    }
+                  },
+                  "medgen": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "MedGen is a portal database about conditions and phenotypes related to Medical Genetics. It aggregates terms from the NIH Genetic Testing Registry (GTR), UMLS, HPO, Orphanet, ClinVar and other sources into concepts, and assigns a unique identifier and a preferred name and symbol. Each entry includes names, identifiers used by other databases, mode of inheritance, clinical features, and map location of the loci affecting the disorder. This database provides links to such resources as:\nGenetic tests registered in the NIH Genetic Testing Registry (GTR), GeneReviews, ClinVar, OMIM, Related genes, Disorders with similar clinical features, Medical and research literature, Practice guidelines, Consumer resources, Ontologies such as HPO and ORDO."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "遺伝医学に関連する症状や表現型に関する情報を集約したポータルデータベースです。NIHのGTR、UMLS、HPO、Orphanet、ClinVar、その他のソースから得られた用語を概念に集約し、一意の識別子（CUI）と優先名を割り当てます。 各エントリーには、名称、他のデータベースで使用される識別子、遺伝様式、臨床的特徴、疾患に影響を与える遺伝子座の地図上の位置が含まれます。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "MedGen"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information (NCBI)"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information (NCBI)"
+                      }
+                    }
+                  },
+                  "mesh": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "This is a database of keywords representing the content of articles and biological information. The keywords are structured in layers to allow users to find more detailed information or perform abstract searches."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "文献や、生物学情報の内容を表すキーワードのデータベースです。このキーワードを利用することで関連する生物学情報を得ることができます。キーワードは階層構造をなしており、より詳細に情報をたどることも、より抽象的な検索をすることも可能です。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "MeSH"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      }
+                    }
+                  },
+                  "mgi": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "This is a comprehensive site for mouse research. The site contains detailed information on mouse genes, gene expression data, polymorphisms and mutations, pathways, data on model rats for hereditary cancers, and phenotypes of each mouse model system. They have developed and provided The Human - Mouse: Disease Connection (HMDC) and Mammalian Phenotype Ontology."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "マウス研究の総合サイトです。マウス遺伝子に関する情報の他、遺伝子発現データ、多型・変異情報、パスウエイ、遺伝性癌症候群モデルラットに関するデータ、マウス各系統の表現型に関する詳細な情報等を提供しています。Mammalian Phenotype Ontology を作成管理しており、 オントロジーの検索・閲覧もできます(http://www.informatics.jax.org/vocab/mp_ontology) 。Human - Mouse: Disease Connection (HMDC) により、ヒトとマウスの遺伝子や表現型を統合して検索ができます。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "MGI"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "The Jackson Laboratory"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "The Jackson Laboratory"
+                      }
+                    }
+                  },
+                  "mirbase": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "miRBase is a database for published microRNA sequences and annotations, which include mature miRNA sequences (indicated by miR), and hairpin structures predicted by sequences that are precursors for miRNA (indicated by mir). A variety of search methods can be used, including by keyword, genomic position, cluster, expression data, and user-provided sequences. Furthermore, these sequences and annotations can be downloaded."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "公開されているmicroRNAの配列について、配列から予測されるmiRNA前駆体のヘアピン構造(mirで示されます)、成熟miRNAの配列(miRで示されます)、文献情報等が登録されています。様々な検索機能が用意されており、キーワード検索、ゲノム位置による検索、クラスター検索、発現実験による検索、ユーザ自身の配列による検索が行えます。全ての配列とアノテーションはダウンロード可能です。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "miRBase"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "Faculty of Life Sciences(The University of Manchester)"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "Faculty of Life Sciences (The University of Manchester)"
+                      }
+                    }
+                  },
+                  "mondo": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "Mondo is an ontology for integrating disease definitions. It collects disease definitions and data models from numerous sources, which include HPO, OMIM, SNOMED CT, ICD, PhenoDB, MedDRA, MedGen, ORDO, DO, GARD, etc. It provides a hierarchical structure which can be used for classification or \"rolling up\" diseases to higher level groupings."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "疾病の定義を統合して構築したオントロジーです。疾病を定義しデータモデルを収録している多くのデータベース（HPO、OMIM、SNOMED CT、ICD、PhenoDB、MedDRA、MedGen、ORDO、DO、GARDなど）から情報を収集しています。開発当初は半自動で構築されていましたが、広範囲に渡り手動でキュレーションされるようになってきています。疾病の個々の症状、特徴の説明はHPOに準拠しており、疾病は階層構造で表示できます。OWL形式を利用したmondo-with-equivalent、obo、jsonの３つのフォーマットで利用可能です。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "MONDO"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "Monarch Initiative"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "Monarch Initiative"
+                      }
+                    }
+                  },
+                  "nando": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "NanbyoData provides informative data related to intractable diseases using Nanbyo Disease Ontology (NANDO). Designated intractable diseases and chronic specific pediatric diseases in Japan are the subject diseases. NANDO, and genes and phenotypes related intractable diseases are downloadable."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "NanbyoDataは難病オントロジー（Nanbyo Disease Ontology, NANDO）を介して国内外の難病関連情報を集積したサイトです。日本の難病関連制度である指定難病・小児慢性特定疾病の対象疾患に関して詳細な分類までを網羅し、その概要（日英）とOMIM、Orphanet、MedGen、Monarch Initiative、KEGG Diseaseへのリンク情報を提供しています。NANDOはサイトからダウンロードして利用できる他、語彙一覧 (http://nanbyodata.jp/ontology/nando) と階層構造 (http://bioportal.bioontology.org/ontologies/NANDO/?p=classes&conceptid=root) がweb上から参照できます。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "NanbyoData"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "Research Organization of Information and Systems Database Center for Life Science"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "情報・システム研究機構　ライフサイエンス統合データベースセンター"
+                      }
+                    }
+                  },
+                  "ncbigene": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "The gene database provides information on gene sequence, structure, location, and function for annotated genes from the NCBI database. Users can search by accession ID or keyword, compare and identify sequences using BLAST, or submit references into function (RIFs) based on experimental results. Bulk download and an update mailing list are available."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "生物種別の遺伝子単位でエントリーを構成しており、NCBIの様々なデータベースを統合的に利用して遺伝子情報を掲載しています。染色体上の位置、配列、発現、構造、機能、ホモロジーデータのような遺伝子をベースとした情報を提供しています。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "NCBI Gene"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      }
+                    }
+                  },
+                  "ncbiprotein": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "NCBI is a portal site for US biological study data. The site contains links to several NIH research resources, most of which are repositories for submission of data from government-funded and/or published projects. Users can search the entire NCBI collection or perform keyword searches of a specific database from the NCBI search bar. Constituent databases contain a wealth of data for download."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "NCBI（米国立バイオテクノロジー情報センター）は、NIH（米国立衛生研究所）のNLM（米国立医学図書館）の一部門として1988年に設立されたバイオインフォマティクス研究組織です。1989年にBLAST、1990年に検索システムEntrezを開発しました。現在では、NCBI内の各種データベースに対する検索を統一的なインタフェースで行えるようにしています。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "NCBI"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      }
+                    }
+                  },
+                  "oma_group": {
+                    "type": "object"
+                  },
+                  "oma_protein": {
+                    "type": "object"
+                  },
+                  "omim_gene": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "OMIM is a database of human disease and genetic information and the online representation of Mendelian Inheritance in Man, a project initiated in the 1960s. The database summarizes heritable traits and provides information on both the trait and experimentally determined genetic causes. The database is manually curated by experts and can be searched by OMIM ID, gene, disease, or phenotype."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "Johns Hopkins大学のVictor A. McKusick 博士が中心となって記述、編集を行っている、ヒトの遺伝子変異と遺伝病のデータベースです。全ての既知のメンデル型遺伝病と12,000以上の遺伝子に関して、テキスト形式の情報やリファレンスが示されます。MEDLINEやEntrezのリンクも含まれます。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "OMIM"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      }
+                    }
+                  },
+                  "omim_phenotype": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "OMIM is a database of human disease and genetic information and the online representation of Mendelian Inheritance in Man, a project initiated in the 1960s. The database summarizes heritable traits and provides information on both the trait and experimentally determined genetic causes. The database is manually curated by experts and can be searched by OMIM ID, gene, disease, or phenotype."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "Johns Hopkins大学のVictor A. McKusick 博士が中心となって記述、編集を行っている、ヒトの遺伝子変異と遺伝病のデータベースです。全ての既知のメンデル型遺伝病と12,000以上の遺伝子に関して、テキスト形式の情報やリファレンスが示されます。MEDLINEやEntrezのリンクも含まれます。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "OMIM"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      }
+                    }
+                  },
+                  "orphanet": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "Orphanet is a portal site for rare diseases and orphan drugs. It provides inventory of rare diseases and classification, inventory of orphan drugs, clinical trials, etc."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "Orphanetは希少疾患患者の診断と治療の向上を図ることを目的とした、希少疾患や希少疾患用医薬品について様々な情報を参照可能にしたデータベースです。疾患や薬に関する一般的な情報をはじめとして、臨床試験情報、関連する論文や、有病率、発症歴、症状、地域情報などを検索可能です。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "Orphanet"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "Orphanet"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "フランス国立保健医学研究所"
+                      }
+                    }
+                  },
+                  "pdb": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "This is an international public repository for three-dimensional structures and structure coordinates (conformations) of proteins and nucleic acids, and the central database for biological structural data. Data obtained through X-ray crystallography and NMR experiments are stored in PDB. In addition to three-dimensional information of proteins, users can find amino acid sequences, protein-related information on GO, and other compounds bound to the protein."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "タンパク質と核酸の３次元構造の構造座標（立体配座）を蓄積している国際的な公共レポジトリです。\n　RCSB PDB （https://integbio.jp/dbcatalog/record/nbdc01865 ）\n　PDBe （https://integbio.jp/dbcatalog/record/nbdc00613 ）\n　PDBj （https://integbio.jp/dbcatalog/record/nbdc00157 ）\n　BMRB （https://integbio.jp/dbcatalog/record/nbdc00380 ）\n上記４つデータベースの集合体として、X線結晶構造解析やNMRなどで実験的に決定されたタンパク質の立体構造データの他に、アミノ酸配列、GOといったタンパク質に関する情報やタンパク質に結合している化合物の情報を統合し提供しています。検証データ登録のためのツールや登録データのダウンロードが可能なFTPサイトを装備しています。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "wwPDB"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "wwPDB consortium"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "wwPDB consortium"
+                      }
+                    }
+                  },
+                  "pfam": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "Pfam Version 26.0 is a comprehensive database of protein families containing multiple sequence alignments and HMMs.\nThis repository provides data on 13,672 protein families.\nThe site can be searched with a known protein sequence for matching families. \nOptions to search for a Pfam family, clan, sequence or structure are available.\nA keyword search option is also provided."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "現在最もよく整備されたタンパク質ドメインデータベースの一つで、膨大な数のタンパク質ファミリーのコレクションを保持しています。手作業で分類を行った高品質のPfam-Aと、機械的に分類を行ったPfam-Bから構成されています。最大の特徴は、検索システムとしてHMMERというプログラムを使用している点であり、これにより高速で精度の高いモチーフの検索を可能にしています。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "Pfam"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "EMBL-EBI"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "EMBL-EBI"
+                      }
+                    }
+                  },
+                  "pubchem_compound": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "PubChem Compound is a database of chemical structrues of validated small molecules. The dataase contains entries for PubChem entities which are grouped by structural identity and similarity. Users can submit compounds and download via FTP."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "化合物名や分子量、CompoundIDなどで化合物の情報を検索することができるサイトです。医薬品名やその効能、LogP値などの物性値も掲載されています。また、類似構造を持つ別の化合物の検索も可能です。PubChem Substanceが一つの化合物に対して異なる情報をもつ複数のエントリをもつ可能性があるのに対し、PubChem CompoundはPubChem Substanceで得られた種々の情報を一つのエントリに集約して提供しています。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "PubChem Compound"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      }
+                    }
+                  },
+                  "pubchem_substance": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "PubChem Substance is a database of samples of chemical entities which links to the biological activity of those samples in PubChem BioAssay. The database contains structural information on substances with links to further information in cases where the substance has been more fully characterized. It consists of records of chemical entities deposited by various contributors, so a chemical entity may be described different records with different data in this database."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "PubChem Substanceは、出版社、研究者、化学ベンダー、製薬会社、および多くの重要なケミカルバイオロジーリソースをもつ研究者によって提供された化学物質とその生物活性に関する情報のオープンアーカイブです。特定の化学物質に関して個々の提供者からの情報が含まれており、１つの化合物に対して提供者が異なる別のレコードとして異なる情報を提供している可能性があります。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "PubChem Substance"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      }
+                    }
+                  },
+                  "pubmed": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "This database contains bibliographic information from journal articles in the field of life science as well as MEDLINE (title, authors, journal name, abstracts). Links are provided for articles with free access to the full article."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "MEDLINEおよび生命科学分野のジャーナル文献の書誌情報（タイトル、著者名、雑誌名、抄録など）を収録したデータベースです。全文をフリーで公開している文献については、提供サイトへのリンクが張られています。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "PubMed"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      }
+                    }
+                  },
+                  "reactome_pathway": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "REACTOME is a database of human pathways for basic research, genome analysis, pathway modeling, systems biology and education. It contains manually curated and peer-reviewed pathway data which are annotated by expert biologists, in collaboration with Reactome editorial staff and cross-referenced to many bioinformatics databases. This database provides an intuitive website to navigate pathway knowledge and a suite of data analysis tools to support the pathway-based analysis of complex experimental and computational data sets. The curated  human pathway data are available to infer orthologous events in 20 non-human species including mouse, rat, chicken, worm, fly, yeast, plant and bacteria. Using species comparison tool, users are able to compare predicted pathways with those of human to find reactions and pathways common to a selected species and human."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "ヒトの生体内の主要反応経路や生化学反応を整備したデータベースです。ヒト以外の20生物種のデータも格納しており、ヒトとの比較ができます。ここに収録されている情報は、それぞれの分野の専門家が編集しているため、非常に信頼性の高いデータベースです。代謝パスウェイ、シグナル伝達や膜輸送、感染など様々なパスウェイが扱われており、SBGN (Sytem Biology Graphical Notation)形式で視覚化されています。パスウエイ解析、生物種間比較、発現解析も行えます。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "REACTOME"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "Reactome team"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "Reactome Team"
+                      }
+                    }
+                  },
+                  "reactome_reaction": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "REACTOME is a database of human pathways for basic research, genome analysis, pathway modeling, systems biology and education. It contains manually curated and peer-reviewed pathway data which are annotated by expert biologists, in collaboration with Reactome editorial staff and cross-referenced to many bioinformatics databases. This database provides an intuitive website to navigate pathway knowledge and a suite of data analysis tools to support the pathway-based analysis of complex experimental and computational data sets. The curated  human pathway data are available to infer orthologous events in 20 non-human species including mouse, rat, chicken, worm, fly, yeast, plant and bacteria. Using species comparison tool, users are able to compare predicted pathways with those of human to find reactions and pathways common to a selected species and human."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "ヒトの生体内の主要反応経路や生化学反応を整備したデータベースです。ヒト以外の20生物種のデータも格納しており、ヒトとの比較ができます。ここに収録されている情報は、それぞれの分野の専門家が編集しているため、非常に信頼性の高いデータベースです。代謝パスウェイ、シグナル伝達や膜輸送、感染など様々なパスウェイが扱われており、SBGN (Sytem Biology Graphical Notation)形式で視覚化されています。パスウエイ解析、生物種間比較、発現解析も行えます。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "REACTOME"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "Reactome team"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "Reactome Team"
+                      }
+                    }
+                  },
+                  "refseq_genomic": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "RefSeq is a database of standard reference genomic, transcript, and protein sequences. The database contains consensus sequence data for over 20,000 organisms and over 27 million proteins and is designed to provide a common basis for experimental studies that can be searched using accession ID, keyword, or BLAST. Bulk data is available for FTP download."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "異なる生物種由来の冗長性を排除したDNA, RNA, タンパク配列を収録したデータベースです。プラスミド、オルガネラ、ウイルス、古細菌、真正細菌、真核生物のアノテーション付けされた配列が含まれています。生物種ごとに、標準となる配列の包括的データセットを提供することを目的としています。配列の情報源はGenBank由来ですが、それらの中から情報を統合して標準となる配列を提供しています。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "RefSeq"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      }
+                    }
+                  },
+                  "refseq_protein": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "RefSeq is a database of standard reference genomic, transcript, and protein sequences. The database contains consensus sequence data for over 20,000 organisms and over 27 million proteins and is designed to provide a common basis for experimental studies that can be searched using accession ID, keyword, or BLAST. Bulk data is available for FTP download."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "異なる生物種由来の冗長性を排除したDNA, RNA, タンパク配列を収録したデータベースです。プラスミド、オルガネラ、ウイルス、古細菌、真正細菌、真核生物のアノテーション付けされた配列が含まれています。生物種ごとに、標準となる配列の包括的データセットを提供することを目的としています。配列の情報源はGenBank由来ですが、それらの中から情報を統合して標準となる配列を提供しています。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "RefSeq"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      }
+                    }
+                  },
+                  "refseq_rna": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "RefSeq is a database of standard reference genomic, transcript, and protein sequences. The database contains consensus sequence data for over 20,000 organisms and over 27 million proteins and is designed to provide a common basis for experimental studies that can be searched using accession ID, keyword, or BLAST. Bulk data is available for FTP download."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "異なる生物種由来の冗長性を排除したDNA, RNA, タンパク配列を収録したデータベースです。プラスミド、オルガネラ、ウイルス、古細菌、真正細菌、真核生物のアノテーション付けされた配列が含まれています。生物種ごとに、標準となる配列の包括的データセットを提供することを目的としています。配列の情報源はGenBank由来ですが、それらの中から情報を統合して標準となる配列を提供しています。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "RefSeq"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      }
+                    }
+                  },
+                  "rgd": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "This is a comprehensive site for rat genome researches. In addition to information on rat genes, the site contains information on rat strains, data on rat models for disease, and publications."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "ラットゲノム研究の総合サイトです。ラット遺伝子に関する情報の他に、ラットの系統に関する情報、病態モデルラットに関するデータ、文献情報等を提供しています。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "RGD"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "Medical College of Wisconsin/Bioinformatics Research Center"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "Medical College of Wisconsin/Bioinformatics Research Center"
+                      }
+                    }
+                  },
+                  "rhea": {
+                    "type": "object"
+                  },
+                  "sra_accession": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "SRA is a database of raw sequence reads from next-generation sequencing systems. The database contains millions of unannotated raw reads generated from a variety of projects. Data can be submitted to the archive or downloaded via FTP."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "次世代シーケンサーによる配列データのレポジトリサイトです。現在扱っているプラットフォームは454(ロシュ)、Genome Analyzer(イルミナ)、SOLiD(アプライドバイオシステムズ)、Heliscope(ヘリコス)。研究単位でデータの登録、配布を行っています。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "SRA"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      }
+                    }
+                  },
+                  "sra_analysis": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "SRA is a database of raw sequence reads from next-generation sequencing systems. The database contains millions of unannotated raw reads generated from a variety of projects. Data can be submitted to the archive or downloaded via FTP."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "次世代シーケンサーによる配列データのレポジトリサイトです。現在扱っているプラットフォームは454(ロシュ)、Genome Analyzer(イルミナ)、SOLiD(アプライドバイオシステムズ)、Heliscope(ヘリコス)。研究単位でデータの登録、配布を行っています。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "SRA"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      }
+                    }
+                  },
+                  "sra_experiment": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "SRA is a database of raw sequence reads from next-generation sequencing systems. The database contains millions of unannotated raw reads generated from a variety of projects. Data can be submitted to the archive or downloaded via FTP."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "次世代シーケンサーによる配列データのレポジトリサイトです。現在扱っているプラットフォームは454(ロシュ)、Genome Analyzer(イルミナ)、SOLiD(アプライドバイオシステムズ)、Heliscope(ヘリコス)。研究単位でデータの登録、配布を行っています。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "SRA"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      }
+                    }
+                  },
+                  "sra_project": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "SRA is a database of raw sequence reads from next-generation sequencing systems. The database contains millions of unannotated raw reads generated from a variety of projects. Data can be submitted to the archive or downloaded via FTP."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "次世代シーケンサーによる配列データのレポジトリサイトです。現在扱っているプラットフォームは454(ロシュ)、Genome Analyzer(イルミナ)、SOLiD(アプライドバイオシステムズ)、Heliscope(ヘリコス)。研究単位でデータの登録、配布を行っています。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "SRA"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      }
+                    }
+                  },
+                  "sra_run": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "SRA is a database of raw sequence reads from next-generation sequencing systems. The database contains millions of unannotated raw reads generated from a variety of projects. Data can be submitted to the archive or downloaded via FTP."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "次世代シーケンサーによる配列データのレポジトリサイトです。現在扱っているプラットフォームは454(ロシュ)、Genome Analyzer(イルミナ)、SOLiD(アプライドバイオシステムズ)、Heliscope(ヘリコス)。研究単位でデータの登録、配布を行っています。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "SRA"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      }
+                    }
+                  },
+                  "sra_sample": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "SRA is a database of raw sequence reads from next-generation sequencing systems. The database contains millions of unannotated raw reads generated from a variety of projects. Data can be submitted to the archive or downloaded via FTP."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "次世代シーケンサーによる配列データのレポジトリサイトです。現在扱っているプラットフォームは454(ロシュ)、Genome Analyzer(イルミナ)、SOLiD(アプライドバイオシステムズ)、Heliscope(ヘリコス)。研究単位でデータの登録、配布を行っています。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "SRA"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      }
+                    }
+                  },
+                  "taxonomy": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "Taxonomy is a database of systematic classifications of organisms repesented in public sequencing databases. The database contains phylogenetic relatonships and nomenclature for an estimated 10% of all living species. Tools include a browser, genetic codes, and a common evolutionary tree. Taxonomic classificatinos can be downloaded via FTP."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "NCBI Entrezデータベースに少なくとも1件以上登録されている全ての生物種と上位分類名を収集したデータベースです。160,000以上の生物種が登録されています。各エントリーには、学名、英名、階層分類、上位階層、Entrezデータベース群の収録数とリンクが含まれています。このデータベースは、種々のデータベース間で生物名の表記を統一することを目的として構築しており、分類学や系統発生学の権威となるものではありません。採用されている生物名や系統分類は、分類学的、系統発生学的に普及している内容と異なる場合があります。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "Taxonomy - NCBI"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "National Center for Biotechnology Information"
+                      }
+                    }
+                  },
+                  "togovar": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "TogoVar (NBDC's integrated database of Japanese genomic variation) is a database that has collected and organized genome sequence differences between individuals (variants) in the Japanese population and disease information associated with them. TogoVar provides variant frequencies in the Japanese population that have been aggregated across research projects. Two available datasets, JGA-NGS and JGA-SNP, are obtained by aggregating individual genomic data that have been registered in the NBDC Human Database / Japanese Genotype-phenotype Archive (JGA). In addition, TogoVar integrates information related to genotypes or phenotypes that has been compiled independently in a variety of different databases and provides information for interpreting variants in a one-stop, easy-to-understand manner.\nUsers can learn how to use it by a movie: https://togotv.dbcls.jp/en/20181012.html"
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "TogoVar（日本人ゲノム多様性統合データベース）は、日本人ゲノム配列の個人による違い（バリアント）とそれに関係する疾患情報などを収集・整理したデータベースです。TogoVarは、研究プロジェクト横断的に集約した日本人におけるバリアントの頻度情報を提供します。利用可能な２つのデータセットであるJGA-NGSとJGA-SNPはNBDCヒトデータベース/Japanese Genotype-phenotype Archive (JGA)に登録されている個人ごとのゲノムデータを集約して得られた頻度情報です。さらに、多種多様なデータベースに散在して収録されてきた遺伝子型や表現型に関連する情報を整理統合し、バリアントを解釈するための情報をワンストップでわかりやすく提供します。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "TogoVar"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "National Bioscience Database Center"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "国立研究開発法人科学技術振興機構　バイオサイエンスデータベースセンター"
+                      }
+                    }
+                  },
+                  "uniprot": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "This database contains information on amino acid sequences and their functions. It is composed of four core databases, UniProtKB, UniRef, UniParc, and Proteomes. UniProtKB contains two types of data, which are manually curated high quality SwissProt annotations based on literature information, and automatically annotated TrEMBL. \r\nUniRef provides results of sequence similarity searches. \r\nUniParc integrates information such as ID for other databases per sequence ID.\r\nProteomes provides proteome data of each organism with completely sequenced genomes."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "アミノ酸配列とその機能情報を掲載している代表的なデータベースです。「UniProtKB」、「UniRef」、「UniParc」の3種類のデータベースから構成されています。\nUniProtKB: 文献情報などを元に手作業で高品質のアノテーションを付けたSwissProtと、機械的にアノテーションを加えたTrEMBLを公開しています。\nUniRef: あらかじめ行われた配列相同性検索の結果を提供しています。\nUniParc: 配列IDごとに他のデータベースのID等の情報をまとめています。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "UniProt"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "UniProt Consortium"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "UniProt Consortium"
+                      }
+                    }
+                  },
+                  "uniprot_mnemonic": {
+                    "properties": {
+                      "description_en": {
+                        "type": "string",
+                        "example": "This database contains information on amino acid sequences and their functions. It is composed of four core databases, UniProtKB, UniRef, UniParc, and Proteomes. UniProtKB contains two types of data, which are manually curated high quality SwissProt annotations based on literature information, and automatically annotated TrEMBL. \r\nUniRef provides results of sequence similarity searches. \r\nUniParc integrates information such as ID for other databases per sequence ID.\r\nProteomes provides proteome data of each organism with completely sequenced genomes."
+                      },
+                      "description_ja": {
+                        "type": "string",
+                        "example": "アミノ酸配列とその機能情報を掲載している代表的なデータベースです。「UniProtKB」、「UniRef」、「UniParc」の3種類のデータベースから構成されています。\nUniProtKB: 文献情報などを元に手作業で高品質のアノテーションを付けたSwissProtと、機械的にアノテーションを加えたTrEMBLを公開しています。\nUniRef: あらかじめ行われた配列相同性検索の結果を提供しています。\nUniParc: 配列IDごとに他のデータベースのID等の情報をまとめています。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "UniProt"
+                      },
+                      "organization_en": {
+                        "type": "string",
+                        "example": "UniProt Consortium"
+                      },
+                      "organization_ja": {
+                        "type": "string",
+                        "example": "UniProt Consortium"
+                      }
+                    }
+                  },
+                  "wikipathways": {
+                    "type": "object"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request"
+            }
+          }
+        }
+      }
+    }
+  }

--- a/yarn.lock
+++ b/yarn.lock
@@ -63,7 +63,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.7":
+"@babel/runtime-corejs3@npm:^7.20.7, @babel/runtime-corejs3@npm:^7.22.15, @babel/runtime-corejs3@npm:^7.23.9":
+  version: 7.23.9
+  resolution: "@babel/runtime-corejs3@npm:7.23.9"
+  dependencies:
+    core-js-pure: "npm:^3.30.2"
+    regenerator-runtime: "npm:^0.14.0"
+  checksum: 10c0/7926ebf38285b41e2a486b25aaa10861db1cfd29accd0b0eaa1338080d853339481f78d8d73e5d1f219a8ad52c477dcd4e7cc3473d1befbb290c77b27ed1ec91
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.7":
   version: 7.23.9
   resolution: "@babel/runtime@npm:7.23.9"
   dependencies:
@@ -80,6 +90,13 @@ __metadata:
     "@babel/helper-validator-identifier": "npm:^7.22.20"
     to-fast-properties: "npm:^2.0.0"
   checksum: 10c0/edc7bb180ce7e4d2aea10c6972fb10474341ac39ba8fdc4a27ffb328368dfdfbf40fca18e441bbe7c483774500d5c05e222cec276c242e952853dcaf4eb884f7
+  languageName: node
+  linkType: hard
+
+"@braintree/sanitize-url@npm:=7.0.0":
+  version: 7.0.0
+  resolution: "@braintree/sanitize-url@npm:7.0.0"
+  checksum: 10c0/d167d0be5281825e5b92e4eabf88e7f39bb757833173e42964fd326958e36d6aa4167d7b1e76547f2749c455985de846f01f9d3165215c81c9e3c41c7afa1a1d
   languageName: node
   linkType: hard
 
@@ -479,6 +496,500 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swagger-api/apidom-ast@npm:^0.95.0":
+  version: 0.95.0
+  resolution: "@swagger-api/apidom-ast@npm:0.95.0"
+  dependencies:
+    "@babel/runtime-corejs3": "npm:^7.20.7"
+    "@swagger-api/apidom-error": "npm:^0.95.0"
+    "@types/ramda": "npm:~0.29.6"
+    ramda: "npm:~0.29.1"
+    ramda-adjunct: "npm:^4.1.1"
+    unraw: "npm:^3.0.0"
+  checksum: 10c0/5f7f01af4f66c051a679c9ac6585bcf8c590b0284212e7cece6eea74ed399e9ef150d340facf3a4d3c9a275f366cf3e2403824774a3ad4d691d667d29b8435ee
+  languageName: node
+  linkType: hard
+
+"@swagger-api/apidom-core@npm:>=0.90.0 <1.0.0, @swagger-api/apidom-core@npm:^0.95.0":
+  version: 0.95.0
+  resolution: "@swagger-api/apidom-core@npm:0.95.0"
+  dependencies:
+    "@babel/runtime-corejs3": "npm:^7.20.7"
+    "@swagger-api/apidom-ast": "npm:^0.95.0"
+    "@swagger-api/apidom-error": "npm:^0.95.0"
+    "@types/ramda": "npm:~0.29.6"
+    minim: "npm:~0.23.8"
+    ramda: "npm:~0.29.1"
+    ramda-adjunct: "npm:^4.1.1"
+    short-unique-id: "npm:^5.0.2"
+    stampit: "npm:^4.3.2"
+  checksum: 10c0/84cba7e52a385786ec48666c0a19c85b2c142657e0541c4377f4b74be485cac54ff52b344c42967aaec8d5c528a220ca5e496b5e013d824ec17bc7bb2ff78ac1
+  languageName: node
+  linkType: hard
+
+"@swagger-api/apidom-error@npm:>=0.90.0 <1.0.0, @swagger-api/apidom-error@npm:^0.95.0":
+  version: 0.95.0
+  resolution: "@swagger-api/apidom-error@npm:0.95.0"
+  dependencies:
+    "@babel/runtime-corejs3": "npm:^7.20.7"
+  checksum: 10c0/7a689d3f1683a0b64cd182740012e6198a7b719fe9d8840dba43dafb9375bdb50e8ac088dcdc600f7e80a9a354b701c3fe50a1a179644cadb25b9f9ab183ce53
+  languageName: node
+  linkType: hard
+
+"@swagger-api/apidom-json-pointer@npm:>=0.90.0 <1.0.0, @swagger-api/apidom-json-pointer@npm:^0.95.0":
+  version: 0.95.0
+  resolution: "@swagger-api/apidom-json-pointer@npm:0.95.0"
+  dependencies:
+    "@babel/runtime-corejs3": "npm:^7.20.7"
+    "@swagger-api/apidom-core": "npm:^0.95.0"
+    "@swagger-api/apidom-error": "npm:^0.95.0"
+    "@types/ramda": "npm:~0.29.6"
+    ramda: "npm:~0.29.1"
+    ramda-adjunct: "npm:^4.0.0"
+  checksum: 10c0/0cf0657742e986525e923e11e1a653352499a78550561bb00d589a9a8a3aaf0544ffcd71c213b903d4ab6755a6e8a51ccb05f7dc4430702bf300f9b9961d3633
+  languageName: node
+  linkType: hard
+
+"@swagger-api/apidom-ns-api-design-systems@npm:^0.95.0":
+  version: 0.95.0
+  resolution: "@swagger-api/apidom-ns-api-design-systems@npm:0.95.0"
+  dependencies:
+    "@babel/runtime-corejs3": "npm:^7.20.7"
+    "@swagger-api/apidom-core": "npm:^0.95.0"
+    "@swagger-api/apidom-error": "npm:^0.95.0"
+    "@swagger-api/apidom-ns-openapi-3-1": "npm:^0.95.0"
+    "@types/ramda": "npm:~0.29.6"
+    ramda: "npm:~0.29.1"
+    ramda-adjunct: "npm:^4.1.1"
+    ts-mixer: "npm:^6.0.3"
+  checksum: 10c0/0fe5f8e5f4a494fbbb2c19279ec45b5894732f649f57fad7d4c4e70ca6bc14467d5e8d60e07085e0a188e2bb35225538cb793e30e194348ea2f94de20421cc78
+  languageName: node
+  linkType: hard
+
+"@swagger-api/apidom-ns-asyncapi-2@npm:^0.95.0":
+  version: 0.95.0
+  resolution: "@swagger-api/apidom-ns-asyncapi-2@npm:0.95.0"
+  dependencies:
+    "@babel/runtime-corejs3": "npm:^7.20.7"
+    "@swagger-api/apidom-core": "npm:^0.95.0"
+    "@swagger-api/apidom-ns-json-schema-draft-7": "npm:^0.95.0"
+    "@types/ramda": "npm:~0.29.6"
+    ramda: "npm:~0.29.1"
+    ramda-adjunct: "npm:^4.1.1"
+    ts-mixer: "npm:^6.0.3"
+  checksum: 10c0/b1552e1b51fad7cc19e1e1192c34733c2b3d529a91b825d0888ac1d690c78996540f833509de63f06f73f491fb61a9068f404b59f4212d7dfea45145aba2bf4b
+  languageName: node
+  linkType: hard
+
+"@swagger-api/apidom-ns-json-schema-draft-4@npm:^0.95.0":
+  version: 0.95.0
+  resolution: "@swagger-api/apidom-ns-json-schema-draft-4@npm:0.95.0"
+  dependencies:
+    "@babel/runtime-corejs3": "npm:^7.20.7"
+    "@swagger-api/apidom-ast": "npm:^0.95.0"
+    "@swagger-api/apidom-core": "npm:^0.95.0"
+    "@types/ramda": "npm:~0.29.6"
+    ramda: "npm:~0.29.1"
+    ramda-adjunct: "npm:^4.1.1"
+    stampit: "npm:^4.3.2"
+  checksum: 10c0/8d22e34d96c8afa2d9a3af62feb5cdc058ccdaa00bef00e94341a3a548568a4fd9f61113cdc2b4ba42c79df2289ef695cb9715ac8127a49cdd0354c3372ee0dd
+  languageName: node
+  linkType: hard
+
+"@swagger-api/apidom-ns-json-schema-draft-6@npm:^0.95.0":
+  version: 0.95.0
+  resolution: "@swagger-api/apidom-ns-json-schema-draft-6@npm:0.95.0"
+  dependencies:
+    "@babel/runtime-corejs3": "npm:^7.20.7"
+    "@swagger-api/apidom-core": "npm:^0.95.0"
+    "@swagger-api/apidom-error": "npm:^0.95.0"
+    "@swagger-api/apidom-ns-json-schema-draft-4": "npm:^0.95.0"
+    "@types/ramda": "npm:~0.29.6"
+    ramda: "npm:~0.29.1"
+    ramda-adjunct: "npm:^4.1.1"
+    stampit: "npm:^4.3.2"
+  checksum: 10c0/fc5f168f0e0532c8132415f59c6b7cf9fab8437807fe0699f5c5c2c6fbeb9a9796d00294195139412b629751e551c68abd9f2d075c558fa622024bc84e9aa7c2
+  languageName: node
+  linkType: hard
+
+"@swagger-api/apidom-ns-json-schema-draft-7@npm:^0.95.0":
+  version: 0.95.0
+  resolution: "@swagger-api/apidom-ns-json-schema-draft-7@npm:0.95.0"
+  dependencies:
+    "@babel/runtime-corejs3": "npm:^7.20.7"
+    "@swagger-api/apidom-core": "npm:^0.95.0"
+    "@swagger-api/apidom-error": "npm:^0.95.0"
+    "@swagger-api/apidom-ns-json-schema-draft-6": "npm:^0.95.0"
+    "@types/ramda": "npm:~0.29.6"
+    ramda: "npm:~0.29.1"
+    ramda-adjunct: "npm:^4.1.1"
+    stampit: "npm:^4.3.2"
+  checksum: 10c0/a412d24108d030dd4a07bb0dc635dc3251d24b8b3ed7caf7ee0730a09a36215de62b66e64c11aea72d0026faa1d0f73a387ea6267a1013c95258d084789a2503
+  languageName: node
+  linkType: hard
+
+"@swagger-api/apidom-ns-openapi-2@npm:^0.95.0":
+  version: 0.95.0
+  resolution: "@swagger-api/apidom-ns-openapi-2@npm:0.95.0"
+  dependencies:
+    "@babel/runtime-corejs3": "npm:^7.20.7"
+    "@swagger-api/apidom-core": "npm:^0.95.0"
+    "@swagger-api/apidom-error": "npm:^0.95.0"
+    "@swagger-api/apidom-ns-json-schema-draft-4": "npm:^0.95.0"
+    "@types/ramda": "npm:~0.29.6"
+    ramda: "npm:~0.29.1"
+    ramda-adjunct: "npm:^4.1.1"
+    ts-mixer: "npm:^6.0.3"
+  checksum: 10c0/c129928ca100572b0bbc3edf0e83caab89a0ec3b71cc86a169f5c085b5a6e8c3ec78d6ceb87a6aaa2f95ff590c1beb3346c75e1b47157ef11f770fbdeaaeca49
+  languageName: node
+  linkType: hard
+
+"@swagger-api/apidom-ns-openapi-3-0@npm:^0.95.0":
+  version: 0.95.0
+  resolution: "@swagger-api/apidom-ns-openapi-3-0@npm:0.95.0"
+  dependencies:
+    "@babel/runtime-corejs3": "npm:^7.20.7"
+    "@swagger-api/apidom-core": "npm:^0.95.0"
+    "@swagger-api/apidom-error": "npm:^0.95.0"
+    "@swagger-api/apidom-ns-json-schema-draft-4": "npm:^0.95.0"
+    "@types/ramda": "npm:~0.29.6"
+    ramda: "npm:~0.29.1"
+    ramda-adjunct: "npm:^4.1.1"
+    ts-mixer: "npm:^6.0.3"
+  checksum: 10c0/7382665add54eeefbaf243d1aa2c9125ee50d0a3cc16442172c64165c3f14952d8e803faac4d4d74683e75f29f67421d13712937f98f0ddfb3b2051c31020517
+  languageName: node
+  linkType: hard
+
+"@swagger-api/apidom-ns-openapi-3-1@npm:>=0.90.0 <1.0.0, @swagger-api/apidom-ns-openapi-3-1@npm:^0.95.0":
+  version: 0.95.0
+  resolution: "@swagger-api/apidom-ns-openapi-3-1@npm:0.95.0"
+  dependencies:
+    "@babel/runtime-corejs3": "npm:^7.20.7"
+    "@swagger-api/apidom-ast": "npm:^0.95.0"
+    "@swagger-api/apidom-core": "npm:^0.95.0"
+    "@swagger-api/apidom-ns-openapi-3-0": "npm:^0.95.0"
+    "@types/ramda": "npm:~0.29.6"
+    ramda: "npm:~0.29.1"
+    ramda-adjunct: "npm:^4.1.1"
+    ts-mixer: "npm:^6.0.3"
+  checksum: 10c0/54c04ed81e71602fd6d76a02835752f53131727c17e751beef3a43279e97a0f9d8b1397cda01d05dd29aa815c8513c6048ded9152eac267ac9c9bc199bd686e8
+  languageName: node
+  linkType: hard
+
+"@swagger-api/apidom-ns-workflows-1@npm:^0.95.0":
+  version: 0.95.0
+  resolution: "@swagger-api/apidom-ns-workflows-1@npm:0.95.0"
+  dependencies:
+    "@babel/runtime-corejs3": "npm:^7.20.7"
+    "@swagger-api/apidom-core": "npm:^0.95.0"
+    "@swagger-api/apidom-ns-openapi-3-1": "npm:^0.95.0"
+    "@types/ramda": "npm:~0.29.6"
+    ramda: "npm:~0.29.1"
+    ramda-adjunct: "npm:^4.1.1"
+    ts-mixer: "npm:^6.0.3"
+  checksum: 10c0/86335829246e33d427a4fbf5245c60056e259f2f6938bca526014963b049be980f12a149d83ddce5999093e048c4e11810f4199eb222fcc10fb6c56794e66a92
+  languageName: node
+  linkType: hard
+
+"@swagger-api/apidom-parser-adapter-api-design-systems-json@npm:^0.95.0":
+  version: 0.95.0
+  resolution: "@swagger-api/apidom-parser-adapter-api-design-systems-json@npm:0.95.0"
+  dependencies:
+    "@babel/runtime-corejs3": "npm:^7.20.7"
+    "@swagger-api/apidom-core": "npm:^0.95.0"
+    "@swagger-api/apidom-ns-api-design-systems": "npm:^0.95.0"
+    "@swagger-api/apidom-parser-adapter-json": "npm:^0.95.0"
+    "@types/ramda": "npm:~0.29.6"
+    ramda: "npm:~0.29.1"
+    ramda-adjunct: "npm:^4.0.0"
+  checksum: 10c0/50059fa2df752e9a23993089f8f25d0fea0a4a139200e2b4fe587a21db6ecf416122697f58aa8b8b6f6aaf7dff64ca5bd0b59f6be1de7d834d8eeddaa3a47320
+  languageName: node
+  linkType: hard
+
+"@swagger-api/apidom-parser-adapter-api-design-systems-yaml@npm:^0.95.0":
+  version: 0.95.0
+  resolution: "@swagger-api/apidom-parser-adapter-api-design-systems-yaml@npm:0.95.0"
+  dependencies:
+    "@babel/runtime-corejs3": "npm:^7.20.7"
+    "@swagger-api/apidom-core": "npm:^0.95.0"
+    "@swagger-api/apidom-ns-api-design-systems": "npm:^0.95.0"
+    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^0.95.0"
+    "@types/ramda": "npm:~0.29.6"
+    ramda: "npm:~0.29.1"
+    ramda-adjunct: "npm:^4.0.0"
+  checksum: 10c0/94eb678415c35c217f63d3bc73c1fc46273db928dfcc3ef081676bc160761d8744a8352c16282cd69c6df39f9787a0752d71c7f98550a71d6e6c6cc062d76e54
+  languageName: node
+  linkType: hard
+
+"@swagger-api/apidom-parser-adapter-asyncapi-json-2@npm:^0.95.0":
+  version: 0.95.0
+  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-json-2@npm:0.95.0"
+  dependencies:
+    "@babel/runtime-corejs3": "npm:^7.20.7"
+    "@swagger-api/apidom-core": "npm:^0.95.0"
+    "@swagger-api/apidom-ns-asyncapi-2": "npm:^0.95.0"
+    "@swagger-api/apidom-parser-adapter-json": "npm:^0.95.0"
+    "@types/ramda": "npm:~0.29.6"
+    ramda: "npm:~0.29.1"
+    ramda-adjunct: "npm:^4.0.0"
+  checksum: 10c0/2130eb0a1dcb605ad9d9047a30435d00b809ed88a405d699ba5806d6c304bab599c5426d09c5f0b287d52809b6e69fa3b48215b649570354cd5fe654381cd4a3
+  languageName: node
+  linkType: hard
+
+"@swagger-api/apidom-parser-adapter-asyncapi-yaml-2@npm:^0.95.0":
+  version: 0.95.0
+  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2@npm:0.95.0"
+  dependencies:
+    "@babel/runtime-corejs3": "npm:^7.20.7"
+    "@swagger-api/apidom-core": "npm:^0.95.0"
+    "@swagger-api/apidom-ns-asyncapi-2": "npm:^0.95.0"
+    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^0.95.0"
+    "@types/ramda": "npm:~0.29.6"
+    ramda: "npm:~0.29.1"
+    ramda-adjunct: "npm:^4.0.0"
+  checksum: 10c0/973b864d803cbdb6a6f38630f5f91fc4856202a173e27af3a7c87193272de5203f908ff4184fe93f764ae936450a1fb49c01c6cf89d17702c55e1c3c548d7308
+  languageName: node
+  linkType: hard
+
+"@swagger-api/apidom-parser-adapter-json@npm:^0.95.0":
+  version: 0.95.0
+  resolution: "@swagger-api/apidom-parser-adapter-json@npm:0.95.0"
+  dependencies:
+    "@babel/runtime-corejs3": "npm:^7.20.7"
+    "@swagger-api/apidom-ast": "npm:^0.95.0"
+    "@swagger-api/apidom-core": "npm:^0.95.0"
+    "@swagger-api/apidom-error": "npm:^0.95.0"
+    "@types/ramda": "npm:~0.29.6"
+    node-gyp: "npm:latest"
+    ramda: "npm:~0.29.1"
+    ramda-adjunct: "npm:^4.1.1"
+    tree-sitter: "npm:=0.20.4"
+    tree-sitter-json: "npm:=0.20.2"
+    web-tree-sitter: "npm:=0.20.3"
+  checksum: 10c0/6b72bf55c76b957d9cca25300cc2cd56d87d1808e8b90acc1d78e7305e2c50ca9631be81ce3f0925b63576970ce99f2188f7650e23a0eb97c683e34441110847
+  languageName: node
+  linkType: hard
+
+"@swagger-api/apidom-parser-adapter-openapi-json-2@npm:^0.95.0":
+  version: 0.95.0
+  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-2@npm:0.95.0"
+  dependencies:
+    "@babel/runtime-corejs3": "npm:^7.20.7"
+    "@swagger-api/apidom-core": "npm:^0.95.0"
+    "@swagger-api/apidom-ns-openapi-2": "npm:^0.95.0"
+    "@swagger-api/apidom-parser-adapter-json": "npm:^0.95.0"
+    "@types/ramda": "npm:~0.29.6"
+    ramda: "npm:~0.29.1"
+    ramda-adjunct: "npm:^4.0.0"
+  checksum: 10c0/f8d53750077549a01b1f01d6a70d2beaeff506a07843bae77437363fc8b30cc689e264dac33c95ba8da53ab7e37b6d9fd218d4eb3c4169253eb2e7ac14aa5fc2
+  languageName: node
+  linkType: hard
+
+"@swagger-api/apidom-parser-adapter-openapi-json-3-0@npm:^0.95.0":
+  version: 0.95.0
+  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-3-0@npm:0.95.0"
+  dependencies:
+    "@babel/runtime-corejs3": "npm:^7.20.7"
+    "@swagger-api/apidom-core": "npm:^0.95.0"
+    "@swagger-api/apidom-ns-openapi-3-0": "npm:^0.95.0"
+    "@swagger-api/apidom-parser-adapter-json": "npm:^0.95.0"
+    "@types/ramda": "npm:~0.29.6"
+    ramda: "npm:~0.29.1"
+    ramda-adjunct: "npm:^4.0.0"
+  checksum: 10c0/df7caf5baa8f42b1b2df7c4678b99fad3b43f8d73958f7e3e0a8c2ea666bee422d0a6dac608f4fd53d73b037aadc6287cbb1d7e2972ba10ef2a1c3c1f11ca48d
+  languageName: node
+  linkType: hard
+
+"@swagger-api/apidom-parser-adapter-openapi-json-3-1@npm:^0.95.0":
+  version: 0.95.0
+  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-3-1@npm:0.95.0"
+  dependencies:
+    "@babel/runtime-corejs3": "npm:^7.20.7"
+    "@swagger-api/apidom-core": "npm:^0.95.0"
+    "@swagger-api/apidom-ns-openapi-3-1": "npm:^0.95.0"
+    "@swagger-api/apidom-parser-adapter-json": "npm:^0.95.0"
+    "@types/ramda": "npm:~0.29.6"
+    ramda: "npm:~0.29.1"
+    ramda-adjunct: "npm:^4.0.0"
+  checksum: 10c0/7ccc407630875e5896f557552e1f6cea9f9f4462a4a4ee8c187fd6041dae070fadaba1737d3c703acb13f48c49926f9aaf37e04c673303ce4cc7a0f98435229c
+  languageName: node
+  linkType: hard
+
+"@swagger-api/apidom-parser-adapter-openapi-yaml-2@npm:^0.95.0":
+  version: 0.95.0
+  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-2@npm:0.95.0"
+  dependencies:
+    "@babel/runtime-corejs3": "npm:^7.20.7"
+    "@swagger-api/apidom-core": "npm:^0.95.0"
+    "@swagger-api/apidom-ns-openapi-2": "npm:^0.95.0"
+    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^0.95.0"
+    "@types/ramda": "npm:~0.29.6"
+    ramda: "npm:~0.29.1"
+    ramda-adjunct: "npm:^4.0.0"
+  checksum: 10c0/756f1e93304112639270f444a4bb8b8513a56881ee1c7afd8bc4e768254acdc3cdbf8146c5687c335b44485f6c9ea5b130aaef911fe5b41a32a1ca3bc798d729
+  languageName: node
+  linkType: hard
+
+"@swagger-api/apidom-parser-adapter-openapi-yaml-3-0@npm:^0.95.0":
+  version: 0.95.0
+  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0@npm:0.95.0"
+  dependencies:
+    "@babel/runtime-corejs3": "npm:^7.20.7"
+    "@swagger-api/apidom-core": "npm:^0.95.0"
+    "@swagger-api/apidom-ns-openapi-3-0": "npm:^0.95.0"
+    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^0.95.0"
+    "@types/ramda": "npm:~0.29.6"
+    ramda: "npm:~0.29.1"
+    ramda-adjunct: "npm:^4.0.0"
+  checksum: 10c0/14285e21d808cf5ce9c13441f98d64edab997881b2b2e7ba357fc858bb7cf589cb90772a519420050111055838fcf17c3edcae9d13abf7ffd88ff0cb1d8fd2f9
+  languageName: node
+  linkType: hard
+
+"@swagger-api/apidom-parser-adapter-openapi-yaml-3-1@npm:^0.95.0":
+  version: 0.95.0
+  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1@npm:0.95.0"
+  dependencies:
+    "@babel/runtime-corejs3": "npm:^7.20.7"
+    "@swagger-api/apidom-core": "npm:^0.95.0"
+    "@swagger-api/apidom-ns-openapi-3-1": "npm:^0.95.0"
+    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^0.95.0"
+    "@types/ramda": "npm:~0.29.6"
+    ramda: "npm:~0.29.1"
+    ramda-adjunct: "npm:^4.0.0"
+  checksum: 10c0/ed6d679ec238cced6d791e670958850ab3d7ef4f9d9e7192930b449747ef27b7e7b9e5177a31d695a5a8644419e820fc6a7b2515487383ec35306c5797ce4e3a
+  languageName: node
+  linkType: hard
+
+"@swagger-api/apidom-parser-adapter-workflows-json-1@npm:^0.95.0":
+  version: 0.95.0
+  resolution: "@swagger-api/apidom-parser-adapter-workflows-json-1@npm:0.95.0"
+  dependencies:
+    "@babel/runtime-corejs3": "npm:^7.20.7"
+    "@swagger-api/apidom-core": "npm:^0.95.0"
+    "@swagger-api/apidom-ns-workflows-1": "npm:^0.95.0"
+    "@swagger-api/apidom-parser-adapter-json": "npm:^0.95.0"
+    "@types/ramda": "npm:~0.29.6"
+    ramda: "npm:~0.29.1"
+    ramda-adjunct: "npm:^4.0.0"
+  checksum: 10c0/9c8d303311a9af0193a85428c9de78704debcab53f1807d6557d8c6b763fdbb5314469ce0a92f3a22e416dd1dfecb8e25468ca15f2f06a33be112b805336d02c
+  languageName: node
+  linkType: hard
+
+"@swagger-api/apidom-parser-adapter-workflows-yaml-1@npm:^0.95.0":
+  version: 0.95.0
+  resolution: "@swagger-api/apidom-parser-adapter-workflows-yaml-1@npm:0.95.0"
+  dependencies:
+    "@babel/runtime-corejs3": "npm:^7.20.7"
+    "@swagger-api/apidom-core": "npm:^0.95.0"
+    "@swagger-api/apidom-ns-workflows-1": "npm:^0.95.0"
+    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^0.95.0"
+    "@types/ramda": "npm:~0.29.6"
+    ramda: "npm:~0.29.1"
+    ramda-adjunct: "npm:^4.0.0"
+  checksum: 10c0/35a693d8f2908d61e006a3883ddf0de90a4c092869a82f4588795ae071c4b27ab04d98817479c3559f44c26fced05bd820d4a3765ef24d58d473449ea35b3a17
+  languageName: node
+  linkType: hard
+
+"@swagger-api/apidom-parser-adapter-yaml-1-2@npm:^0.95.0":
+  version: 0.95.0
+  resolution: "@swagger-api/apidom-parser-adapter-yaml-1-2@npm:0.95.0"
+  dependencies:
+    "@babel/runtime-corejs3": "npm:^7.20.7"
+    "@swagger-api/apidom-ast": "npm:^0.95.0"
+    "@swagger-api/apidom-core": "npm:^0.95.0"
+    "@swagger-api/apidom-error": "npm:^0.95.0"
+    "@types/ramda": "npm:~0.29.6"
+    node-gyp: "npm:latest"
+    ramda: "npm:~0.29.1"
+    ramda-adjunct: "npm:^4.1.1"
+    tree-sitter: "npm:=0.20.4"
+    tree-sitter-yaml: "npm:=0.5.0"
+    web-tree-sitter: "npm:=0.20.3"
+  checksum: 10c0/a43ca54018a1fe6532458fd002a8932ab4bcfdd30a5f6b0c3110f5564d39078fac493e7bb6b8060f580ea0fe12e3bdca760ffea38415f97edb3b48d006c18b57
+  languageName: node
+  linkType: hard
+
+"@swagger-api/apidom-reference@npm:>=0.90.0 <1.0.0":
+  version: 0.95.0
+  resolution: "@swagger-api/apidom-reference@npm:0.95.0"
+  dependencies:
+    "@babel/runtime-corejs3": "npm:^7.20.7"
+    "@swagger-api/apidom-core": "npm:^0.95.0"
+    "@swagger-api/apidom-error": "npm:^0.95.0"
+    "@swagger-api/apidom-json-pointer": "npm:^0.95.0"
+    "@swagger-api/apidom-ns-asyncapi-2": "npm:^0.95.0"
+    "@swagger-api/apidom-ns-openapi-2": "npm:^0.95.0"
+    "@swagger-api/apidom-ns-openapi-3-0": "npm:^0.95.0"
+    "@swagger-api/apidom-ns-openapi-3-1": "npm:^0.95.0"
+    "@swagger-api/apidom-ns-workflows-1": "npm:^0.95.0"
+    "@swagger-api/apidom-parser-adapter-api-design-systems-json": "npm:^0.95.0"
+    "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "npm:^0.95.0"
+    "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "npm:^0.95.0"
+    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "npm:^0.95.0"
+    "@swagger-api/apidom-parser-adapter-json": "npm:^0.95.0"
+    "@swagger-api/apidom-parser-adapter-openapi-json-2": "npm:^0.95.0"
+    "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "npm:^0.95.0"
+    "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "npm:^0.95.0"
+    "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "npm:^0.95.0"
+    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "npm:^0.95.0"
+    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "npm:^0.95.0"
+    "@swagger-api/apidom-parser-adapter-workflows-json-1": "npm:^0.95.0"
+    "@swagger-api/apidom-parser-adapter-workflows-yaml-1": "npm:^0.95.0"
+    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^0.95.0"
+    "@types/ramda": "npm:~0.29.6"
+    axios: "npm:^1.4.0"
+    minimatch: "npm:^7.4.3"
+    process: "npm:^0.11.10"
+    ramda: "npm:~0.29.1"
+    ramda-adjunct: "npm:^4.1.1"
+    stampit: "npm:^4.3.2"
+  dependenciesMeta:
+    "@swagger-api/apidom-error":
+      optional: true
+    "@swagger-api/apidom-json-pointer":
+      optional: true
+    "@swagger-api/apidom-ns-asyncapi-2":
+      optional: true
+    "@swagger-api/apidom-ns-openapi-2":
+      optional: true
+    "@swagger-api/apidom-ns-openapi-3-0":
+      optional: true
+    "@swagger-api/apidom-ns-openapi-3-1":
+      optional: true
+    "@swagger-api/apidom-ns-workflows-1":
+      optional: true
+    "@swagger-api/apidom-parser-adapter-api-design-systems-json":
+      optional: true
+    "@swagger-api/apidom-parser-adapter-api-design-systems-yaml":
+      optional: true
+    "@swagger-api/apidom-parser-adapter-asyncapi-json-2":
+      optional: true
+    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2":
+      optional: true
+    "@swagger-api/apidom-parser-adapter-json":
+      optional: true
+    "@swagger-api/apidom-parser-adapter-openapi-json-2":
+      optional: true
+    "@swagger-api/apidom-parser-adapter-openapi-json-3-0":
+      optional: true
+    "@swagger-api/apidom-parser-adapter-openapi-json-3-1":
+      optional: true
+    "@swagger-api/apidom-parser-adapter-openapi-yaml-2":
+      optional: true
+    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0":
+      optional: true
+    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1":
+      optional: true
+    "@swagger-api/apidom-parser-adapter-workflows-json-1":
+      optional: true
+    "@swagger-api/apidom-parser-adapter-workflows-yaml-1":
+      optional: true
+    "@swagger-api/apidom-parser-adapter-yaml-1-2":
+      optional: true
+  checksum: 10c0/bb8a365fcaf6bc402c12852dec5cce749a1ddd80d7cc68d5ecde11ced356e3eafbe8cc6df2358921d0d97f6d7596052d0d1e978462e155000a095b340284833a
+  languageName: node
+  linkType: hard
+
 "@swc/helpers@npm:0.5.2":
   version: 0.5.2
   resolution: "@swc/helpers@npm:0.5.2"
@@ -517,6 +1028,15 @@ __metadata:
   version: 2.0.7
   resolution: "@types/file-saver@npm:2.0.7"
   checksum: 10c0/c6b88a1aea8eec58469da2a90828fef6e9d5d590c7094fb959783d7c32878af80d39439734f3d41b78355dadb507f606e3d04a29a160c85411c65251e58df847
+  languageName: node
+  linkType: hard
+
+"@types/hast@npm:^2.0.0":
+  version: 2.3.10
+  resolution: "@types/hast@npm:2.3.10"
+  dependencies:
+    "@types/unist": "npm:^2"
+  checksum: 10c0/16daac35d032e656defe1f103f9c09c341a6dc553c7ec17b388274076fa26e904a71ea5ea41fd368a6d5f1e9e53be275c80af7942b9c466d8511d261c9529c7e
   languageName: node
   linkType: hard
 
@@ -607,6 +1127,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/ramda@npm:~0.29.6":
+  version: 0.29.10
+  resolution: "@types/ramda@npm:0.29.10"
+  dependencies:
+    types-ramda: "npm:^0.29.7"
+  checksum: 10c0/3aaa75e172a75ad4f236a348cd26c15ff80e71111c9d6e434e0c9acff71f5c9485ff41c6b62fb77bcca771c0942c6443e9fc46b611363c3d867f83a8d856301a
+  languageName: node
+  linkType: hard
+
 "@types/react-dom@npm:18.2.19":
   version: 18.2.19
   resolution: "@types/react-dom@npm:18.2.19"
@@ -654,6 +1183,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/swagger-ui-react@npm:4.18.3":
+  version: 4.18.3
+  resolution: "@types/swagger-ui-react@npm:4.18.3"
+  dependencies:
+    "@types/react": "npm:*"
+  checksum: 10c0/1e052117e9b5f87019c76018913bd6d23f8f19d64f1db97619eea4c68ab57e86238af33d0aa656b018568add7cc062c2c41451146c74c9bd50935951bb71c74b
+  languageName: node
+  linkType: hard
+
 "@types/unist@npm:*, @types/unist@npm:^3.0.0":
   version: 3.0.2
   resolution: "@types/unist@npm:3.0.2"
@@ -661,10 +1199,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/unist@npm:^2.0.0":
+"@types/unist@npm:^2, @types/unist@npm:^2.0.0":
   version: 2.0.10
   resolution: "@types/unist@npm:2.0.10"
   checksum: 10c0/5f247dc2229944355209ad5c8e83cfe29419fa7f0a6d557421b1985a1500444719cc9efcc42c652b55aab63c931813c88033e0202c1ac684bcd4829d66e44731
+  languageName: node
+  linkType: hard
+
+"@types/use-sync-external-store@npm:^0.0.3":
+  version: 0.0.3
+  resolution: "@types/use-sync-external-store@npm:0.0.3"
+  checksum: 10c0/82824c1051ba40a00e3d47964cdf4546a224e95f172e15a9c62aa3f118acee1c7518b627a34f3aa87298a2039f982e8509f92bfcc18bea7c255c189c293ba547
   languageName: node
   linkType: hard
 
@@ -743,6 +1288,13 @@ __metadata:
   version: 1.9.5
   resolution: "@xobotyi/scrollbar-width@npm:1.9.5"
   checksum: 10c0/4ebc79e4f798e2a5e89a5122f8fc4a086f08a92a44ac020599c4fe20d105b7d76ba06c094260b5f386a75e7ce6f6c518d9fc295228b651296b99c4477f986ac4
+  languageName: node
+  linkType: hard
+
+"@yarnpkg/lockfile@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@yarnpkg/lockfile@npm:1.1.0"
+  checksum: 10c0/0bfa50a3d756623d1f3409bc23f225a1d069424dbc77c6fd2f14fb377390cd57ec703dc70286e081c564be9051ead9ba85d81d66a3e68eeb6eb506d4e0c0fbda
   languageName: node
   linkType: hard
 
@@ -848,6 +1400,15 @@ __metadata:
     normalize-path: "npm:^3.0.0"
     picomatch: "npm:^2.0.4"
   checksum: 10c0/57b06ae984bc32a0d22592c87384cd88fe4511b1dd7581497831c56d41939c8a001b28e7b853e1450f2bf61992dfcaa8ae2d0d161a0a90c4fb631ef07098fbac
+  languageName: node
+  linkType: hard
+
+"argparse@npm:^1.0.10":
+  version: 1.0.10
+  resolution: "argparse@npm:1.0.10"
+  dependencies:
+    sprintf-js: "npm:~1.0.2"
+  checksum: 10c0/b2972c5c23c63df66bca144dbc65d180efa74f25f8fd9b7d9a0a6c88ae839db32df3d54770dcb6460cf840d232b60695d1a6b1053f599d84e73f7437087712de
   languageName: node
   linkType: hard
 
@@ -999,6 +1560,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"at-least-node@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "at-least-node@npm:1.0.0"
+  checksum: 10c0/4c058baf6df1bc5a1697cf182e2029c58cd99975288a13f9e70068ef5d6f4e1f1fd7c4d2c3c4912eae44797d1725be9700995736deca441b39f3e66d8dee97ef
+  languageName: node
+  linkType: hard
+
+"autolinker@npm:^3.11.0":
+  version: 3.16.2
+  resolution: "autolinker@npm:3.16.2"
+  dependencies:
+    tslib: "npm:^2.3.0"
+  checksum: 10c0/91e083bfa4393fdcd29f595e1db657d852fd74cbd1fec719f30f3d57c910e72d5e0a0b10f2b17e1e6297b52b2f5c12eb6d0cbe024c0d92671e81d8ab906fe981
+  languageName: node
+  linkType: hard
+
 "available-typed-arrays@npm:^1.0.5, available-typed-arrays@npm:^1.0.6":
   version: 1.0.6
   resolution: "available-typed-arrays@npm:1.0.6"
@@ -1013,7 +1590,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.6.7":
+"axios@npm:1.6.7, axios@npm:^1.4.0":
   version: 1.6.7
   resolution: "axios@npm:1.6.7"
   dependencies:
@@ -1058,10 +1635,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"base64-js@npm:^1.3.1, base64-js@npm:^1.5.1":
+  version: 1.5.1
+  resolution: "base64-js@npm:1.5.1"
+  checksum: 10c0/f23823513b63173a001030fae4f2dabe283b99a9d324ade3ad3d148e218134676f1ee8568c877cd79ec1c53158dcf2d2ba527a97c606618928ba99dd930102bf
+  languageName: node
+  linkType: hard
+
 "binary-extensions@npm:^2.0.0":
   version: 2.2.0
   resolution: "binary-extensions@npm:2.2.0"
   checksum: 10c0/d73d8b897238a2d3ffa5f59c0241870043aa7471335e89ea5e1ff48edb7c2d0bb471517a3e4c5c3f4c043615caa2717b5f80a5e61e07503d51dc85cb848e665d
+  languageName: node
+  linkType: hard
+
+"bl@npm:^4.0.3":
+  version: 4.1.0
+  resolution: "bl@npm:4.1.0"
+  dependencies:
+    buffer: "npm:^5.5.0"
+    inherits: "npm:^2.0.4"
+    readable-stream: "npm:^3.4.0"
+  checksum: 10c0/02847e1d2cb089c9dc6958add42e3cdeaf07d13f575973963335ac0fdece563a50ac770ac4c8fa06492d2dd276f6cc3b7f08c7cd9c7a7ad0f8d388b2a28def5f
   languageName: node
   linkType: hard
 
@@ -1097,6 +1692,16 @@ __metadata:
   dependencies:
     fill-range: "npm:^7.0.1"
   checksum: 10c0/321b4d675791479293264019156ca322163f02dc06e3c4cab33bb15cd43d80b51efef69b0930cfde3acd63d126ebca24cd0544fa6f261e093a0fb41ab9dda381
+  languageName: node
+  linkType: hard
+
+"buffer@npm:^5.5.0":
+  version: 5.7.1
+  resolution: "buffer@npm:5.7.1"
+  dependencies:
+    base64-js: "npm:^1.3.1"
+    ieee754: "npm:^1.1.13"
+  checksum: 10c0/27cac81cff434ed2876058d72e7c4789d11ff1120ef32c9de48f59eab58179b66710c488987d295ae89a228f835fc66d088652dffeb8e3ba8659f80eb091d55e
   languageName: node
   linkType: hard
 
@@ -1173,7 +1778,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0":
+"chalk@npm:^4.0.0, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -1190,6 +1795,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"character-entities-legacy@npm:^1.0.0":
+  version: 1.1.4
+  resolution: "character-entities-legacy@npm:1.1.4"
+  checksum: 10c0/ea4ca9c29887335eed86d78fc67a640168342b1274da84c097abb0575a253d1265281a5052f9a863979e952bcc267b4ecaaf4fe233a7e1e0d8a47806c65b96c7
+  languageName: node
+  linkType: hard
+
 "character-entities-legacy@npm:^3.0.0":
   version: 3.0.0
   resolution: "character-entities-legacy@npm:3.0.0"
@@ -1197,10 +1809,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"character-entities@npm:^1.0.0":
+  version: 1.2.4
+  resolution: "character-entities@npm:1.2.4"
+  checksum: 10c0/ad015c3d7163563b8a0ee1f587fb0ef305ef344e9fd937f79ca51cccc233786a01d591d989d5bf7b2e66b528ac9efba47f3b1897358324e69932f6d4b25adfe1
+  languageName: node
+  linkType: hard
+
 "character-entities@npm:^2.0.0":
   version: 2.0.2
   resolution: "character-entities@npm:2.0.2"
   checksum: 10c0/b0c645a45bcc90ff24f0e0140f4875a8436b8ef13b6bcd31ec02cfb2ca502b680362aa95386f7815bdc04b6464d48cf191210b3840d7c04241a149ede591a308
+  languageName: node
+  linkType: hard
+
+"character-reference-invalid@npm:^1.0.0":
+  version: 1.1.4
+  resolution: "character-reference-invalid@npm:1.1.4"
+  checksum: 10c0/29f05081c5817bd1e975b0bf61e77b60a40f62ad371d0f0ce0fdb48ab922278bc744d1fbe33771dced751887a8403f265ff634542675c8d7375f6ff4811efd0e
   languageName: node
   linkType: hard
 
@@ -1230,10 +1856,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chownr@npm:^1.1.1":
+  version: 1.1.4
+  resolution: "chownr@npm:1.1.4"
+  checksum: 10c0/ed57952a84cc0c802af900cf7136de643d3aba2eecb59d29344bc2f3f9bf703a301b9d84cdc71f82c3ffc9ccde831b0d92f5b45f91727d6c9da62f23aef9d9db
+  languageName: node
+  linkType: hard
+
 "chownr@npm:^2.0.0":
   version: 2.0.0
   resolution: "chownr@npm:2.0.0"
   checksum: 10c0/594754e1303672171cc04e50f6c398ae16128eb134a88f801bf5354fd96f205320f23536a045d9abd8b51024a149696e51231565891d4efdab8846021ecf88e6
+  languageName: node
+  linkType: hard
+
+"ci-info@npm:^3.7.0":
+  version: 3.9.0
+  resolution: "ci-info@npm:3.9.0"
+  checksum: 10c0/6f0109e36e111684291d46123d491bc4e7b7a1934c3a20dea28cba89f1d4a03acd892f5f6a81ed3855c38647e285a150e3c9ba062e38943bef57fee6c1554c3a
+  languageName: node
+  linkType: hard
+
+"classnames@npm:^2.5.1":
+  version: 2.5.1
+  resolution: "classnames@npm:2.5.1"
+  checksum: 10c0/afff4f77e62cea2d79c39962980bf316bacb0d7c49e13a21adaadb9221e1c6b9d3cdb829d8bb1b23c406f4e740507f37e1dcf506f7e3b7113d17c5bab787aa69
   languageName: node
   linkType: hard
 
@@ -1292,6 +1939,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"comma-separated-tokens@npm:^1.0.0":
+  version: 1.0.8
+  resolution: "comma-separated-tokens@npm:1.0.8"
+  checksum: 10c0/c3bcfeaa6d50313528a006a40bcc0f9576086665c9b48d4b3a76ddd63e7d6174734386c98be1881cbf6ecfc25e1db61cd775a7b896d2ea7a65de28f83a0f9b17
+  languageName: node
+  linkType: hard
+
 "comma-separated-tokens@npm:^2.0.0":
   version: 2.0.3
   resolution: "comma-separated-tokens@npm:2.0.3"
@@ -1313,12 +1967,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cookie@npm:~0.6.0":
+  version: 0.6.0
+  resolution: "cookie@npm:0.6.0"
+  checksum: 10c0/f2318b31af7a31b4ddb4a678d024514df5e705f9be5909a192d7f116cfb6d45cbacf96a473fa733faa95050e7cff26e7832bb3ef94751592f1387b71c8956686
+  languageName: node
+  linkType: hard
+
 "copy-to-clipboard@npm:3.3.3, copy-to-clipboard@npm:^3.3.1":
   version: 3.3.3
   resolution: "copy-to-clipboard@npm:3.3.3"
   dependencies:
     toggle-selection: "npm:^1.0.6"
   checksum: 10c0/3ebf5e8ee00601f8c440b83ec08d838e8eabb068c1fae94a9cda6b42f288f7e1b552f3463635f419af44bf7675afc8d0390d30876cf5c2d5d35f86d9c56a3e5f
+  languageName: node
+  linkType: hard
+
+"core-js-pure@npm:^3.30.2":
+  version: 3.36.0
+  resolution: "core-js-pure@npm:3.36.0"
+  checksum: 10c0/1c5ecb37451bcebaa449e36285d27c4c79d5ff24b8bfd44491ce661cfc12b5c56471c847d306d21a56894338d00abea4993a6f8e07c71d4e887d1f71e410d22e
   languageName: node
   linkType: hard
 
@@ -1335,7 +2003,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2":
+"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
   dependencies:
@@ -1362,6 +2030,13 @@ __metadata:
     mdn-data: "npm:2.0.14"
     source-map: "npm:^0.6.1"
   checksum: 10c0/499a507bfa39b8b2128f49736882c0dd636b0cd3370f2c69f4558ec86d269113286b7df469afc955de6a68b0dba00bc533e40022a73698081d600072d5d83c1c
+  languageName: node
+  linkType: hard
+
+"css.escape@npm:1.5.1":
+  version: 1.5.1
+  resolution: "css.escape@npm:1.5.1"
+  checksum: 10c0/5e09035e5bf6c2c422b40c6df2eb1529657a17df37fda5d0433d722609527ab98090baf25b13970ca754079a0f3161dd3dfc0e743563ded8cfa0749d861c1525
   languageName: node
   linkType: hard
 
@@ -1409,10 +2084,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"decompress-response@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "decompress-response@npm:6.0.0"
+  dependencies:
+    mimic-response: "npm:^3.1.0"
+  checksum: 10c0/bd89d23141b96d80577e70c54fb226b2f40e74a6817652b80a116d7befb8758261ad073a8895648a29cc0a5947021ab66705cb542fa9c143c82022b27c5b175e
+  languageName: node
+  linkType: hard
+
+"deep-extend@npm:0.6.0, deep-extend@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "deep-extend@npm:0.6.0"
+  checksum: 10c0/1c6b0abcdb901e13a44c7d699116d3d4279fdb261983122a3783e7273844d5f2537dc2e1c454a23fcf645917f93fbf8d07101c1d03c015a87faa662755212566
+  languageName: node
+  linkType: hard
+
 "deep-is@npm:^0.1.3":
   version: 0.1.4
   resolution: "deep-is@npm:0.1.4"
   checksum: 10c0/7f0ee496e0dff14a573dc6127f14c95061b448b87b995fc96c017ce0a1e66af1675e73f1d6064407975bc4ea6ab679497a29fff7b5b9c4e99cb10797c1ad0b4c
+  languageName: node
+  linkType: hard
+
+"deepmerge@npm:~4.3.0":
+  version: 4.3.1
+  resolution: "deepmerge@npm:4.3.1"
+  checksum: 10c0/e53481aaf1aa2c4082b5342be6b6d8ad9dfe387bc92ce197a66dea08bd4265904a087e75e464f14d1347cf2ac8afe1e4c16b266e0561cc5df29382d3c5f80044
   languageName: node
   linkType: hard
 
@@ -1450,6 +2148,13 @@ __metadata:
   version: 2.0.3
   resolution: "dequal@npm:2.0.3"
   checksum: 10c0/f98860cdf58b64991ae10205137c0e97d384c3a4edc7f807603887b7c4b850af1224a33d88012009f150861cbee4fa2d322c4cc04b9313bee312e47f6ecaa888
+  languageName: node
+  linkType: hard
+
+"detect-libc@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "detect-libc@npm:2.0.2"
+  checksum: 10c0/a9f4ffcd2701525c589617d98afe5a5d0676c8ea82bcc4ed6f3747241b79f781d36437c59a5e855254c864d36a3e9f8276568b6b531c28d6e53b093a15703f11
   languageName: node
   linkType: hard
 
@@ -1499,6 +2204,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dompurify@npm:=3.0.9":
+  version: 3.0.9
+  resolution: "dompurify@npm:3.0.9"
+  checksum: 10c0/4da4b86e4010822d01392e25f0686367a4f1e1048a4681178c725de9a817410c5650c17b326c08a018f79437b3177a4bdc7faf4c37b0cf2547bc280aa2038a16
+  languageName: node
+  linkType: hard
+
+"drange@npm:^1.0.2":
+  version: 1.1.1
+  resolution: "drange@npm:1.1.1"
+  checksum: 10c0/d63f364467be64d766d2dae10ee7e4f305fa50375f910c7525fb5983cab326ad0f1a4a3abdf2379e7d7949c0011a291114d5c6c238970a940a08a6ccba02f7b3
+  languageName: node
+  linkType: hard
+
 "eastasianwidth@npm:^0.2.0":
   version: 0.2.0
   resolution: "eastasianwidth@npm:0.2.0"
@@ -1526,6 +2245,15 @@ __metadata:
   dependencies:
     iconv-lite: "npm:^0.6.2"
   checksum: 10c0/36d938712ff00fe1f4bac88b43bcffb5930c1efa57bbcdca9d67e1d9d6c57cfb1200fb01efe0f3109b2ce99b231f90779532814a81370a1bd3274a0f58585039
+  languageName: node
+  linkType: hard
+
+"end-of-stream@npm:^1.1.0, end-of-stream@npm:^1.4.1":
+  version: 1.4.4
+  resolution: "end-of-stream@npm:1.4.4"
+  dependencies:
+    once: "npm:^1.4.0"
+  checksum: 10c0/870b423afb2d54bb8d243c63e07c170409d41e20b47eeef0727547aea5740bd6717aca45597a9f2745525667a6b804c1e7bede41f856818faee5806dd9ff3975
   languageName: node
   linkType: hard
 
@@ -2021,6 +2749,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expand-template@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "expand-template@npm:2.0.3"
+  checksum: 10c0/1c9e7afe9acadf9d373301d27f6a47b34e89b3391b1ef38b7471d381812537ef2457e620ae7f819d2642ce9c43b189b3583813ec395e2938319abe356a9b2f51
+  languageName: node
+  linkType: hard
+
 "exponential-backoff@npm:^3.1.1":
   version: 3.1.1
   resolution: "exponential-backoff@npm:3.1.1"
@@ -2059,6 +2794,13 @@ __metadata:
     merge2: "npm:^1.3.0"
     micromatch: "npm:^4.0.4"
   checksum: 10c0/42baad7b9cd40b63e42039132bde27ca2cb3a4950d0a0f9abe4639ea1aa9d3e3b40f98b1fe31cbc0cc17b664c9ea7447d911a152fa34ec5b72977b125a6fc845
+  languageName: node
+  linkType: hard
+
+"fast-json-patch@npm:^3.0.0-1":
+  version: 3.1.1
+  resolution: "fast-json-patch@npm:3.1.1"
+  checksum: 10c0/8a0438b4818bb53153275fe5b38033610e8c9d9eb11869e6a7dc05eb92fa70f3caa57015e344eb3ae1e71c7a75ad4cc6bc2dc9e0ff281d6ed8ecd44505210ca8
   languageName: node
   linkType: hard
 
@@ -2115,6 +2857,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fault@npm:^1.0.0":
+  version: 1.0.4
+  resolution: "fault@npm:1.0.4"
+  dependencies:
+    format: "npm:^0.2.0"
+  checksum: 10c0/c86c11500c1b676787296f31ade8473adcc6784f118f07c1a9429730b6288d0412f96e069ce010aa57e4f65a9cccb5abee8868bbe3c5f10de63b20482c9baebd
+  languageName: node
+  linkType: hard
+
 "file-entry-cache@npm:^6.0.1":
   version: 6.0.1
   resolution: "file-entry-cache@npm:6.0.1"
@@ -2154,6 +2905,15 @@ __metadata:
     locate-path: "npm:^6.0.0"
     path-exists: "npm:^4.0.0"
   checksum: 10c0/062c5a83a9c02f53cdd6d175a37ecf8f87ea5bbff1fdfb828f04bfa021441bc7583e8ebc0872a4c1baab96221fb8a8a275a19809fb93fbc40bd69ec35634069a
+  languageName: node
+  linkType: hard
+
+"find-yarn-workspace-root@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "find-yarn-workspace-root@npm:2.0.0"
+  dependencies:
+    micromatch: "npm:^4.0.2"
+  checksum: 10c0/b0d3843013fbdaf4e57140e0165889d09fa61745c9e85da2af86e54974f4cc9f1967e40f0d8fc36a79d53091f0829c651d06607d552582e53976f3cd8f4e5689
   languageName: node
   linkType: hard
 
@@ -2212,6 +2972,32 @@ __metadata:
     combined-stream: "npm:^1.0.8"
     mime-types: "npm:^2.1.12"
   checksum: 10c0/cb6f3ac49180be03ff07ba3ff125f9eba2ff0b277fb33c7fc47569fc5e616882c5b1c69b9904c4c4187e97dd0419dd03b134174756f296dec62041e6527e2c6e
+  languageName: node
+  linkType: hard
+
+"format@npm:^0.2.0":
+  version: 0.2.2
+  resolution: "format@npm:0.2.2"
+  checksum: 10c0/6032ba747541a43abf3e37b402b2f72ee08ebcb58bf84d816443dd228959837f1cddf1e8775b29fa27ff133f4bd146d041bfca5f9cf27f048edf3d493cf8fee6
+  languageName: node
+  linkType: hard
+
+"fs-constants@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "fs-constants@npm:1.0.0"
+  checksum: 10c0/a0cde99085f0872f4d244e83e03a46aa387b74f5a5af750896c6b05e9077fac00e9932fdf5aef84f2f16634cd473c63037d7a512576da7d5c2b9163d1909f3a8
+  languageName: node
+  linkType: hard
+
+"fs-extra@npm:^9.0.0":
+  version: 9.1.0
+  resolution: "fs-extra@npm:9.1.0"
+  dependencies:
+    at-least-node: "npm:^1.0.0"
+    graceful-fs: "npm:^4.2.0"
+    jsonfile: "npm:^6.0.1"
+    universalify: "npm:^2.0.0"
+  checksum: 10c0/9b808bd884beff5cb940773018179a6b94a966381d005479f00adda6b44e5e3d4abf765135773d849cc27efe68c349e4a7b86acd7d3306d5932c14f3a4b17a92
   languageName: node
   linkType: hard
 
@@ -2318,6 +3104,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"github-from-package@npm:0.0.0":
+  version: 0.0.0
+  resolution: "github-from-package@npm:0.0.0"
+  checksum: 10c0/737ee3f52d0a27e26332cde85b533c21fcdc0b09fb716c3f8e522cfaa9c600d4a631dec9fcde179ec9d47cca89017b7848ed4d6ae6b6b78f936c06825b1fcc12
+  languageName: node
+  linkType: hard
+
 "glob-parent@npm:^5.1.2, glob-parent@npm:~5.1.2":
   version: 5.1.2
   resolution: "glob-parent@npm:5.1.2"
@@ -2406,7 +3199,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.2.11, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6":
+"graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.11, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10c0/386d011a553e02bc594ac2ca0bd6d9e4c22d7fa8cfbfc448a6d148c59ea881b092db9dbe3547ae4b88e55f1b01f7c4a2ecc53b310c042793e63aa44cf6c257f2
@@ -2482,6 +3275,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hast-util-parse-selector@npm:^2.0.0":
+  version: 2.2.5
+  resolution: "hast-util-parse-selector@npm:2.2.5"
+  checksum: 10c0/29b7ee77960ded6a99d30c287d922243071cc07b39f2006f203bd08ee54eb8f66bdaa86ef6527477c766e2382d520b60ee4e4087f189888c35d8bcc020173648
+  languageName: node
+  linkType: hard
+
 "hast-util-to-jsx-runtime@npm:^2.0.0":
   version: 2.3.0
   resolution: "hast-util-to-jsx-runtime@npm:2.3.0"
@@ -2511,6 +3311,26 @@ __metadata:
   dependencies:
     "@types/hast": "npm:^3.0.0"
   checksum: 10c0/b898bc9fe27884b272580d15260b6bbdabe239973a147e97fa98c45fa0ffec967a481aaa42291ec34fb56530dc2d484d473d7e2bae79f39c83f3762307edfea8
+  languageName: node
+  linkType: hard
+
+"hastscript@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "hastscript@npm:6.0.0"
+  dependencies:
+    "@types/hast": "npm:^2.0.0"
+    comma-separated-tokens: "npm:^1.0.0"
+    hast-util-parse-selector: "npm:^2.0.0"
+    property-information: "npm:^5.0.0"
+    space-separated-tokens: "npm:^1.0.0"
+  checksum: 10c0/f76d9cf373cb075c8523c8ad52709f09f7e02b7c9d3152b8d35c65c265b9f1878bed6023f215a7d16523921036d40a7da292cb6f4399af9b5eccac2a5a5eb330
+  languageName: node
+  linkType: hard
+
+"highlight.js@npm:^10.4.1, highlight.js@npm:~10.7.0":
+  version: 10.7.3
+  resolution: "highlight.js@npm:10.7.3"
+  checksum: 10c0/073837eaf816922427a9005c56c42ad8786473dc042332dfe7901aa065e92bc3d94ebf704975257526482066abb2c8677cc0326559bb8621e046c21c5991c434
   languageName: node
   linkType: hard
 
@@ -2573,10 +3393,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ieee754@npm:^1.1.13, ieee754@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "ieee754@npm:1.2.1"
+  checksum: 10c0/b0782ef5e0935b9f12883a2e2aa37baa75da6e66ce6515c168697b42160807d9330de9a32ec1ed73149aea02e0d822e572bca6f1e22bdcbd2149e13b050b17bb
+  languageName: node
+  linkType: hard
+
 "ignore@npm:^5.2.0":
   version: 5.3.1
   resolution: "ignore@npm:5.3.1"
   checksum: 10c0/703f7f45ffb2a27fb2c5a8db0c32e7dee66b33a225d28e8db4e1be6474795f606686a6e3bcc50e1aa12f2042db4c9d4a7d60af3250511de74620fbed052ea4cd
+  languageName: node
+  linkType: hard
+
+"immutable@npm:^3.x.x":
+  version: 3.8.2
+  resolution: "immutable@npm:3.8.2"
+  checksum: 10c0/fb6a2999ad3bda9e51741721e42547076dd492635ee4df9241224055fe953ec843583a700088cc4915f23dc326e5084f4e17f1bbd7388c3e872ef5a242e0ac5e
   languageName: node
   linkType: hard
 
@@ -2621,10 +3455,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2":
+"inherits@npm:2, inherits@npm:^2.0.1, inherits@npm:^2.0.3, inherits@npm:^2.0.4":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 10c0/4e531f648b29039fb7426fb94075e6545faa1eb9fe83c29f0b6d9e7263aceb4289d2d4557db0d428188eeb449cc7c5e77b0a0b2c4e248ff2a65933a0dee49ef2
+  languageName: node
+  linkType: hard
+
+"ini@npm:~1.3.0":
+  version: 1.3.8
+  resolution: "ini@npm:1.3.8"
+  checksum: 10c0/ec93838d2328b619532e4f1ff05df7909760b6f66d9c9e2ded11e5c1897d6f2f9980c54dd638f88654b00919ce31e827040631eab0a3969e4d1abefa0719516a
   languageName: node
   linkType: hard
 
@@ -2656,6 +3497,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"invariant@npm:^2.2.2":
+  version: 2.2.4
+  resolution: "invariant@npm:2.2.4"
+  dependencies:
+    loose-envify: "npm:^1.0.0"
+  checksum: 10c0/5af133a917c0bcf65e84e7f23e779e7abc1cd49cb7fdc62d00d1de74b0d8c1b5ee74ac7766099fb3be1b05b26dfc67bab76a17030d2fe7ea2eef867434362dfc
+  languageName: node
+  linkType: hard
+
 "ip@npm:^2.0.0":
   version: 2.0.0
   resolution: "ip@npm:2.0.0"
@@ -2663,10 +3513,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-alphabetical@npm:^1.0.0":
+  version: 1.0.4
+  resolution: "is-alphabetical@npm:1.0.4"
+  checksum: 10c0/1505b1de5a1fd74022c05fb21b0e683a8f5229366bac8dc4d34cf6935bcfd104d1125a5e6b083fb778847629f76e5bdac538de5367bdf2b927a1356164e23985
+  languageName: node
+  linkType: hard
+
 "is-alphabetical@npm:^2.0.0":
   version: 2.0.1
   resolution: "is-alphabetical@npm:2.0.1"
   checksum: 10c0/932367456f17237533fd1fc9fe179df77957271020b83ea31da50e5cc472d35ef6b5fb8147453274ffd251134472ce24eb6f8d8398d96dee98237cdb81a6c9a7
+  languageName: node
+  linkType: hard
+
+"is-alphanumerical@npm:^1.0.0":
+  version: 1.0.4
+  resolution: "is-alphanumerical@npm:1.0.4"
+  dependencies:
+    is-alphabetical: "npm:^1.0.0"
+    is-decimal: "npm:^1.0.0"
+  checksum: 10c0/d623abae7130a7015c6bf33d99151d4e7005572fd170b86568ff4de5ae86ac7096608b87dd4a1d4dbbd497e392b6396930ba76c9297a69455909cebb68005905
   languageName: node
   linkType: hard
 
@@ -2759,10 +3626,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-decimal@npm:^1.0.0":
+  version: 1.0.4
+  resolution: "is-decimal@npm:1.0.4"
+  checksum: 10c0/a4ad53c4c5c4f5a12214e7053b10326711f6a71f0c63ba1314a77bd71df566b778e4ebd29f9fb6815f07a4dc50c3767fb19bd6fc9fa05e601410f1d64ffeac48
+  languageName: node
+  linkType: hard
+
 "is-decimal@npm:^2.0.0":
   version: 2.0.1
   resolution: "is-decimal@npm:2.0.1"
   checksum: 10c0/8085dd66f7d82f9de818fba48b9e9c0429cb4291824e6c5f2622e96b9680b54a07a624cfc663b24148b8e853c62a1c987cfe8b0b5a13f5156991afaf6736e334
+  languageName: node
+  linkType: hard
+
+"is-docker@npm:^2.0.0":
+  version: 2.2.1
+  resolution: "is-docker@npm:2.2.1"
+  bin:
+    is-docker: cli.js
+  checksum: 10c0/e828365958d155f90c409cdbe958f64051d99e8aedc2c8c4cd7c89dcf35329daed42f7b99346f7828df013e27deb8f721cf9408ba878c76eb9e8290235fbcdcc
   languageName: node
   linkType: hard
 
@@ -2804,6 +3687,13 @@ __metadata:
   dependencies:
     is-extglob: "npm:^2.1.1"
   checksum: 10c0/17fb4014e22be3bbecea9b2e3a76e9e34ff645466be702f1693e8f1ee1adac84710d0be0bd9f967d6354036fd51ab7c2741d954d6e91dae6bb69714de92c197a
+  languageName: node
+  linkType: hard
+
+"is-hexadecimal@npm:^1.0.0":
+  version: 1.0.4
+  resolution: "is-hexadecimal@npm:1.0.4"
+  checksum: 10c0/ec4c64e5624c0f240922324bc697e166554f09d3ddc7633fc526084502626445d0a871fbd8cae52a9844e83bd0bb414193cc5a66806d7b2867907003fc70c5ea
   languageName: node
   linkType: hard
 
@@ -2862,6 +3752,13 @@ __metadata:
   version: 4.1.0
   resolution: "is-plain-obj@npm:4.1.0"
   checksum: 10c0/32130d651d71d9564dc88ba7e6fda0e91a1010a3694648e9f4f47bb6080438140696d3e3e15c741411d712e47ac9edc1a8a9de1fe76f3487b0d90be06ac9975e
+  languageName: node
+  linkType: hard
+
+"is-plain-object@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "is-plain-object@npm:5.0.0"
+  checksum: 10c0/893e42bad832aae3511c71fd61c0bf61aa3a6d853061c62a307261842727d0d25f761ce9379f7ba7226d6179db2a3157efa918e7fe26360f3bf0842d9f28942c
   languageName: node
   linkType: hard
 
@@ -2944,6 +3841,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-wsl@npm:^2.1.1":
+  version: 2.2.0
+  resolution: "is-wsl@npm:2.2.0"
+  dependencies:
+    is-docker: "npm:^2.0.0"
+  checksum: 10c0/a6fa2d370d21be487c0165c7a440d567274fbba1a817f2f0bfa41cc5e3af25041d84267baa22df66696956038a43973e72fca117918c91431920bdef490fa25e
+  languageName: node
+  linkType: hard
+
 "isarray@npm:^2.0.5":
   version: 2.0.5
   resolution: "isarray@npm:2.0.5"
@@ -2998,6 +3904,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"js-file-download@npm:^0.4.12":
+  version: 0.4.12
+  resolution: "js-file-download@npm:0.4.12"
+  checksum: 10c0/3caec1491fa744214409e0bcb1fb18d76e3d56715c477ee033cb7d8becb5cf777803409dc1995c913bf1a2270dac98d78f07d83bba319b8e800bc7bf2a7266a7
+  languageName: node
+  linkType: hard
+
 "js-tokens@npm:^3.0.0 || ^4.0.0, js-tokens@npm:^4.0.0":
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
@@ -3005,7 +3918,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.1.0":
+"js-yaml@npm:=4.1.0, js-yaml@npm:^4.1.0":
   version: 4.1.0
   resolution: "js-yaml@npm:4.1.0"
   dependencies:
@@ -3044,6 +3957,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-stable-stringify@npm:^1.0.2":
+  version: 1.1.1
+  resolution: "json-stable-stringify@npm:1.1.1"
+  dependencies:
+    call-bind: "npm:^1.0.5"
+    isarray: "npm:^2.0.5"
+    jsonify: "npm:^0.0.1"
+    object-keys: "npm:^1.1.1"
+  checksum: 10c0/3801e3eeccbd030afb970f54bea690a079cfea7d9ed206a1b17ca9367f4b7772c764bf77a48f03e56b50e5f7ee7d11c52339fe20d8d7ccead003e4ca69e4cfde
+  languageName: node
+  linkType: hard
+
 "json5@npm:^1.0.2":
   version: 1.0.2
   resolution: "json5@npm:1.0.2"
@@ -3059,6 +3984,26 @@ __metadata:
   version: 3.2.1
   resolution: "jsonc-parser@npm:3.2.1"
   checksum: 10c0/ada66dec143d7f9cb0e2d0d29c69e9ce40d20f3a4cb96b0c6efb745025ac7f9ba647d7ac0990d0adfc37a2d2ae084a12009a9c833dbdbeadf648879a99b9df89
+  languageName: node
+  linkType: hard
+
+"jsonfile@npm:^6.0.1":
+  version: 6.1.0
+  resolution: "jsonfile@npm:6.1.0"
+  dependencies:
+    graceful-fs: "npm:^4.1.6"
+    universalify: "npm:^2.0.0"
+  dependenciesMeta:
+    graceful-fs:
+      optional: true
+  checksum: 10c0/4f95b5e8a5622b1e9e8f33c96b7ef3158122f595998114d1e7f03985649ea99cb3cd99ce1ed1831ae94c8c8543ab45ebd044207612f31a56fd08462140e46865
+  languageName: node
+  linkType: hard
+
+"jsonify@npm:^0.0.1":
+  version: 0.0.1
+  resolution: "jsonify@npm:0.0.1"
+  checksum: 10c0/7f5499cdd59a0967ed35bda48b7cec43d850bbc8fb955cdd3a1717bb0efadbe300724d5646de765bb7a99fc1c3ab06eb80d93503c6faaf99b4ff50a3326692f6
   languageName: node
   linkType: hard
 
@@ -3080,6 +4025,15 @@ __metadata:
   dependencies:
     json-buffer: "npm:3.0.1"
   checksum: 10c0/aa52f3c5e18e16bb6324876bb8b59dd02acf782a4b789c7b2ae21107fab95fab3890ed448d4f8dba80ce05391eeac4bfabb4f02a20221342982f806fa2cf271e
+  languageName: node
+  linkType: hard
+
+"klaw-sync@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "klaw-sync@npm:6.0.0"
+  dependencies:
+    graceful-fs: "npm:^4.1.11"
+  checksum: 10c0/00d8e4c48d0d699b743b3b028e807295ea0b225caf6179f51029e19783a93ad8bb9bccde617d169659fbe99559d73fb35f796214de031d0023c26b906cecd70a
   languageName: node
   linkType: hard
 
@@ -3135,10 +4089,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.debounce@npm:^4":
+  version: 4.0.8
+  resolution: "lodash.debounce@npm:4.0.8"
+  checksum: 10c0/762998a63e095412b6099b8290903e0a8ddcb353ac6e2e0f2d7e7d03abd4275fe3c689d88960eb90b0dde4f177554d51a690f22a343932ecbc50a5d111849987
+  languageName: node
+  linkType: hard
+
 "lodash.merge@npm:^4.6.2":
   version: 4.6.2
   resolution: "lodash.merge@npm:4.6.2"
   checksum: 10c0/402fa16a1edd7538de5b5903a90228aa48eb5533986ba7fa26606a49db2572bf414ff73a2c9f5d5fd36b31c46a5d5c7e1527749c07cbcf965ccff5fbdf32c506
+  languageName: node
+  linkType: hard
+
+"lodash@npm:^4.15.0, lodash@npm:^4.17.21":
+  version: 4.17.21
+  resolution: "lodash@npm:4.17.21"
+  checksum: 10c0/d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
   languageName: node
   linkType: hard
 
@@ -3149,7 +4117,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
+"loose-envify@npm:^1.0.0, loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
@@ -3157,6 +4125,16 @@ __metadata:
   bin:
     loose-envify: cli.js
   checksum: 10c0/655d110220983c1a4b9c0c679a2e8016d4b67f6e9c7b5435ff5979ecdb20d0813f4dec0a08674fcbdd4846a3f07edbb50a36811fd37930b94aaa0d9daceb017e
+  languageName: node
+  linkType: hard
+
+"lowlight@npm:^1.17.0":
+  version: 1.20.0
+  resolution: "lowlight@npm:1.20.0"
+  dependencies:
+    fault: "npm:^1.0.0"
+    highlight.js: "npm:~10.7.0"
+  checksum: 10c0/728bce6f6fe8b157f48d3324e597f452ce0eed2ccff1c0f41a9047380f944e971eb45bceb31f08fbb64d8f338dabb166f10049b35b92c7ec5cf0241d6adb3dea
   languageName: node
   linkType: hard
 
@@ -3582,7 +4560,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"micromatch@npm:^4.0.4":
+"micromatch@npm:^4.0.2, micromatch@npm:^4.0.4":
   version: 4.0.5
   resolution: "micromatch@npm:4.0.5"
   dependencies:
@@ -3608,6 +4586,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mimic-response@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "mimic-response@npm:3.1.0"
+  checksum: 10c0/0d6f07ce6e03e9e4445bee655202153bdb8a98d67ee8dc965ac140900d7a2688343e6b4c9a72cfc9ef2f7944dfd76eef4ab2482eb7b293a68b84916bac735362
+  languageName: node
+  linkType: hard
+
+"minim@npm:~0.23.8":
+  version: 0.23.8
+  resolution: "minim@npm:0.23.8"
+  dependencies:
+    lodash: "npm:^4.15.0"
+  checksum: 10c0/51563ef7481a262ae9bda18ae927b339977f77f1a11adfba0d7bef0096dbd9303ca9d6cb5d7ffea68c16b47fc124358670bc0bee136289f61d6ae3632256577f
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:9.0.3, minimatch@npm:^9.0.1, minimatch@npm:^9.0.3":
   version: 9.0.3
   resolution: "minimatch@npm:9.0.3"
@@ -3626,7 +4620,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.2.0, minimist@npm:^1.2.6":
+"minimatch@npm:^7.4.3":
+  version: 7.4.6
+  resolution: "minimatch@npm:7.4.6"
+  dependencies:
+    brace-expansion: "npm:^2.0.1"
+  checksum: 10c0/e587bf3d90542555a3d58aca94c549b72d58b0a66545dd00eef808d0d66e5d9a163d3084da7f874e83ca8cc47e91c670e6c6f6593a3e7bb27fcc0e6512e87c67
+  languageName: node
+  linkType: hard
+
+"minimist@npm:^1.2.0, minimist@npm:^1.2.3, minimist@npm:^1.2.6":
   version: 1.2.8
   resolution: "minimist@npm:1.2.8"
   checksum: 10c0/19d3fcdca050087b84c2029841a093691a91259a47def2f18222f41e7645a0b7c44ef4b40e88a1e58a40c84d2ef0ee6047c55594d298146d0eb3f6b737c20ce6
@@ -3717,6 +4720,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mkdirp-classic@npm:^0.5.2, mkdirp-classic@npm:^0.5.3":
+  version: 0.5.3
+  resolution: "mkdirp-classic@npm:0.5.3"
+  checksum: 10c0/95371d831d196960ddc3833cc6907e6b8f67ac5501a6582f47dfae5eb0f092e9f8ce88e0d83afcae95d6e2b61a01741ba03714eeafb6f7a6e9dcc158ac85b168
+  languageName: node
+  linkType: hard
+
 "mkdirp@npm:^1.0.3":
   version: 1.0.4
   resolution: "mkdirp@npm:1.0.4"
@@ -3752,6 +4762,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nan@npm:^2.14.0, nan@npm:^2.17.0, nan@npm:^2.18.0":
+  version: 2.18.0
+  resolution: "nan@npm:2.18.0"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10c0/9209d80134fdb98c0afe35c1372d2b930a0a8d3c52706cb5e4257a27e9845c375f7a8daedadadec8d6403ca2eebb3b37d362ff5d1ec03249462abf65fef2a148
+  languageName: node
+  linkType: hard
+
 "nano-css@npm:^5.6.1":
   version: 5.6.1
   resolution: "nano-css@npm:5.6.1"
@@ -3777,6 +4796,13 @@ __metadata:
   bin:
     nanoid: bin/nanoid.cjs
   checksum: 10c0/e3fb661aa083454f40500473bb69eedb85dc160e763150b9a2c567c7e9ff560ce028a9f833123b618a6ea742e311138b591910e795614a629029e86e180660f3
+  languageName: node
+  linkType: hard
+
+"napi-build-utils@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "napi-build-utils@npm:1.0.2"
+  checksum: 10c0/37fd2cd0ff2ad20073ce78d83fd718a740d568b225924e753ae51cb69d68f330c80544d487e5e5bd18e28702ed2ca469c2424ad948becd1862c1b0209542b2e9
   languageName: node
   linkType: hard
 
@@ -3846,6 +4872,39 @@ __metadata:
   bin:
     next: dist/bin/next
   checksum: 10c0/dbb1ef8d22eec29a9127d28ed46eb34f14e3f7f7b4e4b91dc96027feb4d9ead554a804275484d9a54026e6e55d632d3997561e598c1fb8e8956e77614f39765f
+  languageName: node
+  linkType: hard
+
+"node-abi@npm:^3.3.0":
+  version: 3.56.0
+  resolution: "node-abi@npm:3.56.0"
+  dependencies:
+    semver: "npm:^7.3.5"
+  checksum: 10c0/1cdaee96ba3898905a9ad775dd88556478fcd73bbe815e575725209da37057d187fb96e7efb785e331f4b3725e9939014a69d2edd7bf6969fad73344e1fcaf2f
+  languageName: node
+  linkType: hard
+
+"node-abort-controller@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "node-abort-controller@npm:3.1.1"
+  checksum: 10c0/f7ad0e7a8e33809d4f3a0d1d65036a711c39e9d23e0319d80ebe076b9a3b4432b4d6b86a7fab65521de3f6872ffed36fc35d1327487c48eb88c517803403eda3
+  languageName: node
+  linkType: hard
+
+"node-domexception@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "node-domexception@npm:1.0.0"
+  checksum: 10c0/5e5d63cda29856402df9472335af4bb13875e1927ad3be861dc5ebde38917aecbf9ae337923777af52a48c426b70148815e890a5d72760f1b4d758cc671b1a2b
+  languageName: node
+  linkType: hard
+
+"node-fetch-commonjs@npm:^3.3.2":
+  version: 3.3.2
+  resolution: "node-fetch-commonjs@npm:3.3.2"
+  dependencies:
+    node-domexception: "npm:^1.0.0"
+    web-streams-polyfill: "npm:^3.0.3"
+  checksum: 10c0/87d36ed3e6dcb9dea96783700bc0becf0fdbcdc26c975e16b01a0d3a6e2f420c7e589e765bbfad461ae5377d4c5bd5f6937969a9dd34a0d736a81ac898f5c26a
   languageName: node
   linkType: hard
 
@@ -3983,12 +5042,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"once@npm:^1.3.0":
+"once@npm:^1.3.0, once@npm:^1.3.1, once@npm:^1.4.0":
   version: 1.4.0
   resolution: "once@npm:1.4.0"
   dependencies:
     wrappy: "npm:1"
   checksum: 10c0/5d48aca287dfefabd756621c5dfce5c91a549a93e9fdb7b8246bc4c4790aa2ec17b34a260530474635147aeb631a2dcc8b32c613df0675f96041cbb8244517d0
+  languageName: node
+  linkType: hard
+
+"open@npm:^7.4.2":
+  version: 7.4.2
+  resolution: "open@npm:7.4.2"
+  dependencies:
+    is-docker: "npm:^2.0.0"
+    is-wsl: "npm:^2.1.1"
+  checksum: 10c0/77573a6a68f7364f3a19a4c80492712720746b63680ee304555112605ead196afe91052bd3c3d165efdf4e9d04d255e87de0d0a77acec11ef47fd5261251813f
   languageName: node
   linkType: hard
 
@@ -4003,6 +5072,13 @@ __metadata:
     prelude-ls: "npm:^1.2.1"
     type-check: "npm:^0.4.0"
   checksum: 10c0/66fba794d425b5be51353035cf3167ce6cfa049059cbb93229b819167687e0f48d2bc4603fcb21b091c99acb516aae1083624675b15c4765b2e4693a085e959c
+  languageName: node
+  linkType: hard
+
+"os-tmpdir@npm:~1.0.2":
+  version: 1.0.2
+  resolution: "os-tmpdir@npm:1.0.2"
+  checksum: 10c0/f438450224f8e2687605a8dd318f0db694b6293c5d835ae509a69e97c8de38b6994645337e5577f5001115470414638978cc49da1cdcc25106dad8738dc69990
   languageName: node
   linkType: hard
 
@@ -4049,6 +5125,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parse-entities@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "parse-entities@npm:2.0.0"
+  dependencies:
+    character-entities: "npm:^1.0.0"
+    character-entities-legacy: "npm:^1.0.0"
+    character-reference-invalid: "npm:^1.0.0"
+    is-alphanumerical: "npm:^1.0.0"
+    is-decimal: "npm:^1.0.0"
+    is-hexadecimal: "npm:^1.0.0"
+  checksum: 10c0/f85a22c0ea406ff26b53fdc28641f01cc36fa49eb2e3135f02693286c89ef0bcefc2262d99b3688e20aac2a14fd10b75c518583e875c1b9fe3d1f937795e0854
+  languageName: node
+  linkType: hard
+
 "parse-entities@npm:^4.0.0":
   version: 4.0.1
   resolution: "parse-entities@npm:4.0.1"
@@ -4074,6 +5164,31 @@ __metadata:
     json-parse-even-better-errors: "npm:^2.3.0"
     lines-and-columns: "npm:^1.1.6"
   checksum: 10c0/77947f2253005be7a12d858aedbafa09c9ae39eb4863adf330f7b416ca4f4a08132e453e08de2db46459256fb66afaac5ee758b44fe6541b7cdaf9d252e59585
+  languageName: node
+  linkType: hard
+
+"patch-package@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "patch-package@npm:8.0.0"
+  dependencies:
+    "@yarnpkg/lockfile": "npm:^1.1.0"
+    chalk: "npm:^4.1.2"
+    ci-info: "npm:^3.7.0"
+    cross-spawn: "npm:^7.0.3"
+    find-yarn-workspace-root: "npm:^2.0.0"
+    fs-extra: "npm:^9.0.0"
+    json-stable-stringify: "npm:^1.0.2"
+    klaw-sync: "npm:^6.0.0"
+    minimist: "npm:^1.2.6"
+    open: "npm:^7.4.2"
+    rimraf: "npm:^2.6.3"
+    semver: "npm:^7.5.3"
+    slash: "npm:^2.0.0"
+    tmp: "npm:^0.0.33"
+    yaml: "npm:^2.2.2"
+  bin:
+    patch-package: index.js
+  checksum: 10c0/690eab0537e953a3fd7d32bb23f0e82f97cd448f8244c3227ed55933611a126f9476397325c06ad2c11d881a19b427a02bd1881bee78d89f1731373fc4fe0fee
   languageName: node
   linkType: hard
 
@@ -4165,6 +5280,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prebuild-install@npm:^7.1.1":
+  version: 7.1.1
+  resolution: "prebuild-install@npm:7.1.1"
+  dependencies:
+    detect-libc: "npm:^2.0.0"
+    expand-template: "npm:^2.0.3"
+    github-from-package: "npm:0.0.0"
+    minimist: "npm:^1.2.3"
+    mkdirp-classic: "npm:^0.5.3"
+    napi-build-utils: "npm:^1.0.1"
+    node-abi: "npm:^3.3.0"
+    pump: "npm:^3.0.0"
+    rc: "npm:^1.2.7"
+    simple-get: "npm:^4.0.0"
+    tar-fs: "npm:^2.0.0"
+    tunnel-agent: "npm:^0.6.0"
+  bin:
+    prebuild-install: bin.js
+  checksum: 10c0/6dc70f36b0f4adcb2fe0ed38d874ab28b571fb1a9725d769e8ba3f64a15831e58462de09f3e6e64569bcc4a3e03b9328b56faa0d45fe10ae1574478814536c76
+  languageName: node
+  linkType: hard
+
 "prelude-ls@npm:^1.2.1":
   version: 1.2.1
   resolution: "prelude-ls@npm:1.2.1"
@@ -4190,10 +5327,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prismjs@npm:^1.27.0":
+  version: 1.29.0
+  resolution: "prismjs@npm:1.29.0"
+  checksum: 10c0/d906c4c4d01b446db549b4f57f72d5d7e6ccaca04ecc670fb85cea4d4b1acc1283e945a9cbc3d81819084a699b382f970e02f9d1378e14af9808d366d9ed7ec6
+  languageName: node
+  linkType: hard
+
+"prismjs@npm:~1.27.0":
+  version: 1.27.0
+  resolution: "prismjs@npm:1.27.0"
+  checksum: 10c0/841cbf53e837a42df9155c5ce1be52c4a0a8967ac916b52a27d066181a3578186c634e52d06d0547fb62b65c486b99b95f826dd54966619f9721b884f486b498
+  languageName: node
+  linkType: hard
+
 "proc-log@npm:^3.0.0":
   version: 3.0.0
   resolution: "proc-log@npm:3.0.0"
   checksum: 10c0/f66430e4ff947dbb996058f6fd22de2c66612ae1a89b097744e17fb18a4e8e7a86db99eda52ccf15e53f00b63f4ec0b0911581ff2aac0355b625c8eac509b0dc
+  languageName: node
+  linkType: hard
+
+"process@npm:^0.11.10":
+  version: 0.11.10
+  resolution: "process@npm:0.11.10"
+  checksum: 10c0/40c3ce4b7e6d4b8c3355479df77aeed46f81b279818ccdc500124e6a5ab882c0cc81ff7ea16384873a95a74c4570b01b120f287abbdd4c877931460eca6084b3
   languageName: node
   linkType: hard
 
@@ -4218,6 +5376,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"property-information@npm:^5.0.0":
+  version: 5.6.0
+  resolution: "property-information@npm:5.6.0"
+  dependencies:
+    xtend: "npm:^4.0.0"
+  checksum: 10c0/d54b77c31dc13bb6819559080b2c67d37d94be7dc271f404f139a16a57aa96fcc0b3ad806d4a5baef9e031744853e4afe3df2e37275aacb1f78079bbb652c5af
+  languageName: node
+  linkType: hard
+
 "property-information@npm:^6.0.0":
   version: 6.4.1
   resolution: "property-information@npm:6.4.1"
@@ -4232,6 +5399,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pump@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "pump@npm:3.0.0"
+  dependencies:
+    end-of-stream: "npm:^1.1.0"
+    once: "npm:^1.3.1"
+  checksum: 10c0/bbdeda4f747cdf47db97428f3a135728669e56a0ae5f354a9ac5b74556556f5446a46f720a8f14ca2ece5be9b4d5d23c346db02b555f46739934cc6c093a5478
+  languageName: node
+  linkType: hard
+
 "punycode@npm:^2.1.0":
   version: 2.3.1
   resolution: "punycode@npm:2.3.1"
@@ -4239,10 +5416,75 @@ __metadata:
   languageName: node
   linkType: hard
 
+"qs@npm:^6.10.2":
+  version: 6.11.2
+  resolution: "qs@npm:6.11.2"
+  dependencies:
+    side-channel: "npm:^1.0.4"
+  checksum: 10c0/4f95d4ff18ed480befcafa3390022817ffd3087fc65f146cceb40fc5edb9fa96cb31f648cae2fa96ca23818f0798bd63ad4ca369a0e22702fcd41379b3ab6571
+  languageName: node
+  linkType: hard
+
+"querystringify@npm:^2.1.1":
+  version: 2.2.0
+  resolution: "querystringify@npm:2.2.0"
+  checksum: 10c0/3258bc3dbdf322ff2663619afe5947c7926a6ef5fb78ad7d384602974c467fadfc8272af44f5eb8cddd0d011aae8fabf3a929a8eee4b86edcc0a21e6bd10f9aa
+  languageName: node
+  linkType: hard
+
 "queue-microtask@npm:^1.2.2":
   version: 1.2.3
   resolution: "queue-microtask@npm:1.2.3"
   checksum: 10c0/900a93d3cdae3acd7d16f642c29a642aea32c2026446151f0778c62ac089d4b8e6c986811076e1ae180a694cedf077d453a11b58ff0a865629a4f82ab558e102
+  languageName: node
+  linkType: hard
+
+"ramda-adjunct@npm:^4.0.0, ramda-adjunct@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "ramda-adjunct@npm:4.1.1"
+  peerDependencies:
+    ramda: ">= 0.29.0"
+  checksum: 10c0/bebd3c265da96528f4fa8645131735a800923de52d76cfa949984967211ef977ab9c6ea1d1bb8accff1c04133042f563dfe914065c224a8e8dcefda401fb85fe
+  languageName: node
+  linkType: hard
+
+"ramda@npm:~0.29.1":
+  version: 0.29.1
+  resolution: "ramda@npm:0.29.1"
+  checksum: 10c0/5de53a07400959c1a704c366ec52b1b8cd9a444dc1f9cdf17d607e0b9eeaa38cbaea309d43e59dbd7f36731ba977a64d40092555c0e7c2d4a41e8e922239c0ba
+  languageName: node
+  linkType: hard
+
+"randexp@npm:^0.5.3":
+  version: 0.5.3
+  resolution: "randexp@npm:0.5.3"
+  dependencies:
+    drange: "npm:^1.0.2"
+    ret: "npm:^0.2.0"
+  checksum: 10c0/44ad4e6e7661c090939e062916ccf1477de27eb2b91dfa8c113de9f3116ddf2016ac090323d5d2fa0947c3ff8e9b24798ee5e25cb2c37f22df2e72cda56232b6
+  languageName: node
+  linkType: hard
+
+"randombytes@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "randombytes@npm:2.1.0"
+  dependencies:
+    safe-buffer: "npm:^5.1.0"
+  checksum: 10c0/50395efda7a8c94f5dffab564f9ff89736064d32addf0cc7e8bf5e4166f09f8ded7a0849ca6c2d2a59478f7d90f78f20d8048bca3cdf8be09d8e8a10790388f3
+  languageName: node
+  linkType: hard
+
+"rc@npm:^1.2.7":
+  version: 1.2.8
+  resolution: "rc@npm:1.2.8"
+  dependencies:
+    deep-extend: "npm:^0.6.0"
+    ini: "npm:~1.3.0"
+    minimist: "npm:^1.2.0"
+    strip-json-comments: "npm:~2.0.1"
+  bin:
+    rc: ./cli.js
+  checksum: 10c0/24a07653150f0d9ac7168e52943cc3cb4b7a22c0e43c7dff3219977c2fdca5a2760a304a029c20811a0e79d351f57d46c9bde216193a0f73978496afc2b85b15
   languageName: node
   linkType: hard
 
@@ -4255,6 +5497,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-copy-to-clipboard@npm:5.1.0":
+  version: 5.1.0
+  resolution: "react-copy-to-clipboard@npm:5.1.0"
+  dependencies:
+    copy-to-clipboard: "npm:^3.3.1"
+    prop-types: "npm:^15.8.1"
+  peerDependencies:
+    react: ^15.3.0 || 16 || 17 || 18
+  checksum: 10c0/de70d9f9c2d17cee207888ed791d4a042c300e5ca732503434d49e6745cff56c0d5ebcc82ab86237e9c2248e636d1d031b9f9cf9913ecec61d82a0e5ebc93881
+  languageName: node
+  linkType: hard
+
+"react-debounce-input@npm:=3.3.0":
+  version: 3.3.0
+  resolution: "react-debounce-input@npm:3.3.0"
+  dependencies:
+    lodash.debounce: "npm:^4"
+    prop-types: "npm:^15.8.1"
+  peerDependencies:
+    react: ^15.3.0 || 16 || 17 || 18
+  checksum: 10c0/a015dc31ebb2777bdcc14b2b466994ff670f823c978bd5d3ee0bfd7955ccf4de48fadeac39a0a97bd8d628502c0808f384e48bf650d6a141b2f04c43275f0e29
+  languageName: node
+  linkType: hard
+
 "react-dom@npm:18.2.0":
   version: 18.2.0
   resolution: "react-dom@npm:18.2.0"
@@ -4264,6 +5530,37 @@ __metadata:
   peerDependencies:
     react: ^18.2.0
   checksum: 10c0/66dfc5f93e13d0674e78ef41f92ed21dfb80f9c4ac4ac25a4b51046d41d4d2186abc915b897f69d3d0ebbffe6184e7c5876f2af26bfa956f179225d921be713a
+  languageName: node
+  linkType: hard
+
+"react-immutable-proptypes@npm:2.2.0":
+  version: 2.2.0
+  resolution: "react-immutable-proptypes@npm:2.2.0"
+  dependencies:
+    invariant: "npm:^2.2.2"
+  peerDependencies:
+    immutable: ">=3.6.2"
+  checksum: 10c0/4f3e147303be418d157a00246c9988068df0d21cb92e40f9d78a09538da71b967f5ddbd7f7facf54f05b5ddb011cc717afa82c8c490b0188bf90a6251acc9fb9
+  languageName: node
+  linkType: hard
+
+"react-immutable-pure-component@npm:^2.2.0":
+  version: 2.2.2
+  resolution: "react-immutable-pure-component@npm:2.2.2"
+  peerDependencies:
+    immutable: ">= 2 || >= 4.0.0-rc"
+    react: ">= 16.6"
+    react-dom: ">= 16.6"
+  checksum: 10c0/d13dc10069bd13059ab91741169c6adaa2a44efb425fc3cf7506925f8cfcde40ef8c7d88f0ac5977a9b1eb5b6456f7fe530a1c670df727424dd72a1642163675
+  languageName: node
+  linkType: hard
+
+"react-inspector@npm:^6.0.1":
+  version: 6.0.2
+  resolution: "react-inspector@npm:6.0.2"
+  peerDependencies:
+    react: ^16.8.4 || ^17.0.0 || ^18.0.0
+  checksum: 10c0/8f9b23c21b4d95722e28c9455c2bf00fd9437347714382594461f98e5b9954d60864d0f4e74e881639b065e752a97ba52a65e39930c234072e5bff291bb02b5e
   languageName: node
   linkType: hard
 
@@ -4295,6 +5592,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-redux@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "react-redux@npm:9.1.0"
+  dependencies:
+    "@types/use-sync-external-store": "npm:^0.0.3"
+    use-sync-external-store: "npm:^1.0.0"
+  peerDependencies:
+    "@types/react": ^18.2.25
+    react: ^18.0
+    react-native: ">=0.69"
+    redux: ^5.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    react-native:
+      optional: true
+    redux:
+      optional: true
+  checksum: 10c0/53161b5dc4d109020fbc42d26906ace92fed9ba1d7ab6274af60e9c0684583d20d1c8ec6d58601ac7b833c6468a652bbf3d4a102149d1793cb8a28b05b042f73
+  languageName: node
+  linkType: hard
+
 "react-select@npm:5.8.0":
   version: 5.8.0
   resolution: "react-select@npm:5.8.0"
@@ -4312,6 +5631,21 @@ __metadata:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
   checksum: 10c0/b4b98aaf117ee5cc4642871b7bd51fd0e2697988d0b880f30b21e933ca90258959147117d8aada36713b622e0e4cb06bd18ec02069f3f108896e0d31e69e3c16
+  languageName: node
+  linkType: hard
+
+"react-syntax-highlighter@npm:^15.5.0":
+  version: 15.5.0
+  resolution: "react-syntax-highlighter@npm:15.5.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.3.1"
+    highlight.js: "npm:^10.4.1"
+    lowlight: "npm:^1.17.0"
+    prismjs: "npm:^1.27.0"
+    refractor: "npm:^3.6.0"
+  peerDependencies:
+    react: ">= 0.14.0"
+  checksum: 10c0/2bf57a1ea151f688efc7eba355677577c9bb55f05f9df7ef86627aae42f63f505486cddf3f4a628aecc51ec75e89beb9533201570d03201c4bf7d69d61d2545d
   languageName: node
   linkType: hard
 
@@ -4374,12 +5708,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0":
+  version: 3.6.2
+  resolution: "readable-stream@npm:3.6.2"
+  dependencies:
+    inherits: "npm:^2.0.3"
+    string_decoder: "npm:^1.1.1"
+    util-deprecate: "npm:^1.0.1"
+  checksum: 10c0/e37be5c79c376fdd088a45fa31ea2e423e5d48854be7a22a58869b4e84d25047b193f6acb54f1012331e1bcd667ffb569c01b99d36b0bd59658fb33f513511b7
+  languageName: node
+  linkType: hard
+
 "readdirp@npm:~3.6.0":
   version: 3.6.0
   resolution: "readdirp@npm:3.6.0"
   dependencies:
     picomatch: "npm:^2.2.1"
   checksum: 10c0/6fa848cf63d1b82ab4e985f4cf72bd55b7dcfd8e0a376905804e48c3634b7e749170940ba77b32804d5fe93b3cc521aa95a8d7e7d725f830da6d93f3669ce66b
+  languageName: node
+  linkType: hard
+
+"redux-immutable@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "redux-immutable@npm:4.0.0"
+  peerDependencies:
+    immutable: ^3.8.1 || ^4.0.0-rc.1
+  checksum: 10c0/c706c9f72a1fbce92d54ab9117ab641b6d7ee69f2860ec6de827dbed5bed918d4677a0895e6564bb59011202bb5e639cf69f4e2d2d14086053b32e5c4e35f512
+  languageName: node
+  linkType: hard
+
+"redux@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "redux@npm:5.0.1"
+  checksum: 10c0/b10c28357194f38e7d53b760ed5e64faa317cc63de1fb95bc5d9e127fab956392344368c357b8e7a9bedb0c35b111e7efa522210cfdc3b3c75e5074718e9069c
   languageName: node
   linkType: hard
 
@@ -4395,6 +5756,17 @@ __metadata:
     globalthis: "npm:^1.0.3"
     which-builtin-type: "npm:^1.1.3"
   checksum: 10c0/68f2a21494a9f4f5acc19bda5213236aa7fc02f9953ce2b18670c63b9ca3dec294dcabbb9d394d98cd2fc0de46b7cd6354614a60a33cabdbb5de9a6f7115f9a6
+  languageName: node
+  linkType: hard
+
+"refractor@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "refractor@npm:3.6.0"
+  dependencies:
+    hastscript: "npm:^6.0.0"
+    parse-entities: "npm:^2.0.0"
+    prismjs: "npm:~1.27.0"
+  checksum: 10c0/63ab62393c8c2fd7108c2ea1eff721c0ad2a1a6eee60fdd1b47f4bb25cf298667dc97d041405b3e718b0817da12b37a86ed07ebee5bd2ca6405611f1bae456db
   languageName: node
   linkType: hard
 
@@ -4438,6 +5810,39 @@ __metadata:
     unified: "npm:^11.0.0"
     vfile: "npm:^6.0.0"
   checksum: 10c0/7a9534847ea70e78cf09227a4302af7e491f625fd092351a1b1ee27a2de0a369ac4acf069682e8a8ec0a55847b3e83f0be76b2028aa90e98e69e21420b9794c3
+  languageName: node
+  linkType: hard
+
+"remarkable@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "remarkable@npm:2.0.1"
+  dependencies:
+    argparse: "npm:^1.0.10"
+    autolinker: "npm:^3.11.0"
+  bin:
+    remarkable: bin/remarkable.js
+  checksum: 10c0/e2c23bfd2e45234110bc3220e44fcac5e4a8199691ff6959d9cd0bac34ffca2f123d3913946cbef517018bc8e5ab00beafc527a04782b7afbe5e9706d1c0c77a
+  languageName: node
+  linkType: hard
+
+"repeat-string@npm:^1.5.2":
+  version: 1.6.1
+  resolution: "repeat-string@npm:1.6.1"
+  checksum: 10c0/87fa21bfdb2fbdedc44b9a5b118b7c1239bdd2c2c1e42742ef9119b7d412a5137a1d23f1a83dc6bb686f4f27429ac6f542e3d923090b44181bafa41e8ac0174d
+  languageName: node
+  linkType: hard
+
+"requires-port@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "requires-port@npm:1.0.0"
+  checksum: 10c0/b2bfdd09db16c082c4326e573a82c0771daaf7b53b9ce8ad60ea46aa6e30aaf475fe9b164800b89f93b748d2c234d8abff945d2551ba47bf5698e04cd7713267
+  languageName: node
+  linkType: hard
+
+"reselect@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "reselect@npm:5.1.0"
+  checksum: 10c0/b0ed789f4f6f10dfbd23741823726793384932969aa7ce8f584c882ad87620a02b09b5d1146cd2ea6eaa0953b3fd9f7df22f113893af73f35f28432a8a4294de
   languageName: node
   linkType: hard
 
@@ -4514,6 +5919,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ret@npm:^0.2.0":
+  version: 0.2.2
+  resolution: "ret@npm:0.2.2"
+  checksum: 10c0/1a41e543913cda851abb1dae4852efa97bb693ce58fde3b51cc1cae94e2599dd70b91ad6268a4a07fc238305be06fed91723ef6d08863c48a0d02e0a74b943cd
+  languageName: node
+  linkType: hard
+
 "retry@npm:^0.12.0":
   version: 0.12.0
   resolution: "retry@npm:0.12.0"
@@ -4525,6 +5937,17 @@ __metadata:
   version: 1.0.4
   resolution: "reusify@npm:1.0.4"
   checksum: 10c0/c19ef26e4e188f408922c46f7ff480d38e8dfc55d448310dfb518736b23ed2c4f547fb64a6ed5bdba92cd7e7ddc889d36ff78f794816d5e71498d645ef476107
+  languageName: node
+  linkType: hard
+
+"rimraf@npm:^2.6.3":
+  version: 2.7.1
+  resolution: "rimraf@npm:2.7.1"
+  dependencies:
+    glob: "npm:^7.1.3"
+  bin:
+    rimraf: ./bin.js
+  checksum: 10c0/4eef73d406c6940927479a3a9dee551e14a54faf54b31ef861250ac815172bade86cc6f7d64a4dc5e98b65e4b18a2e1c9ff3b68d296be0c748413f092bb0dd40
   languageName: node
   linkType: hard
 
@@ -4566,6 +5989,13 @@ __metadata:
     has-symbols: "npm:^1.0.3"
     isarray: "npm:^2.0.5"
   checksum: 10c0/833d3d950fc7507a60075f9bfaf41ec6dac7c50c7a9d62b1e6b071ecc162185881f92e594ff95c1a18301c881352dd6fd236d56999d5819559db7b92da9c28af
+  languageName: node
+  linkType: hard
+
+"safe-buffer@npm:^5.0.1, safe-buffer@npm:^5.1.0, safe-buffer@npm:~5.2.0":
+  version: 5.2.1
+  resolution: "safe-buffer@npm:5.2.1"
+  checksum: 10c0/6501914237c0a86e9675d4e51d89ca3c21ffd6a31642efeba25ad65720bce6921c9e7e974e5be91a786b25aa058b5303285d3c15dbabf983a919f5f630d349f3
   languageName: node
   linkType: hard
 
@@ -4632,7 +6062,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.5, semver@npm:^7.5.4":
+"semver@npm:^7.3.5, semver@npm:^7.5.3, semver@npm:^7.5.4":
   version: 7.6.0
   resolution: "semver@npm:7.6.0"
   dependencies:
@@ -4640,6 +6070,15 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 10c0/fbfe717094ace0aa8d6332d7ef5ce727259815bd8d8815700853f4faf23aacbd7192522f0dc5af6df52ef4fa85a355ebd2f5d39f554bd028200d6cf481ab9b53
+  languageName: node
+  linkType: hard
+
+"serialize-error@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "serialize-error@npm:8.1.0"
+  dependencies:
+    type-fest: "npm:^0.20.2"
+  checksum: 10c0/8cfd89f43ca93e283c5f1d16178a536bdfac9bc6029f4a9df988610cc399bc4f2478d1f10ce40b9dff66b863a5158a19b438fbec929045c96d92174f6bca1e88
   languageName: node
   linkType: hard
 
@@ -4675,6 +6114,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sha.js@npm:^2.4.11":
+  version: 2.4.11
+  resolution: "sha.js@npm:2.4.11"
+  dependencies:
+    inherits: "npm:^2.0.1"
+    safe-buffer: "npm:^5.0.1"
+  bin:
+    sha.js: ./bin.js
+  checksum: 10c0/b7a371bca8821c9cc98a0aeff67444a03d48d745cb103f17228b96793f455f0eb0a691941b89ea1e60f6359207e36081d9be193252b0f128e0daf9cfea2815a5
+  languageName: node
+  linkType: hard
+
 "shebang-command@npm:^2.0.0":
   version: 2.0.0
   resolution: "shebang-command@npm:2.0.0"
@@ -4688,6 +6139,16 @@ __metadata:
   version: 3.0.0
   resolution: "shebang-regex@npm:3.0.0"
   checksum: 10c0/1dbed0726dd0e1152a92696c76c7f06084eb32a90f0528d11acd764043aacf76994b2fb30aa1291a21bd019d6699164d048286309a278855ee7bec06cf6fb690
+  languageName: node
+  linkType: hard
+
+"short-unique-id@npm:^5.0.2":
+  version: 5.0.3
+  resolution: "short-unique-id@npm:5.0.3"
+  bin:
+    short-unique-id: bin/short-unique-id
+    suid: bin/short-unique-id
+  checksum: 10c0/8b9cdfd79304424ba304cb82e1cc27171be158946139ac344c14313f76ede41dec0106fa2fc98b0f6d7b06460eeac87ce8a9ee19b44070eab3ee49f02f733d09
   languageName: node
   linkType: hard
 
@@ -4707,6 +6168,31 @@ __metadata:
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
   checksum: 10c0/41602dce540e46d599edba9d9860193398d135f7ff72cab629db5171516cfae628d21e7bfccde1bbfdf11c48726bc2a6d1a8fb8701125852fbfda7cf19c6aa83
+  languageName: node
+  linkType: hard
+
+"simple-concat@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "simple-concat@npm:1.0.1"
+  checksum: 10c0/62f7508e674414008910b5397c1811941d457dfa0db4fd5aa7fa0409eb02c3609608dfcd7508cace75b3a0bf67a2a77990711e32cd213d2c76f4fd12ee86d776
+  languageName: node
+  linkType: hard
+
+"simple-get@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "simple-get@npm:4.0.1"
+  dependencies:
+    decompress-response: "npm:^6.0.0"
+    once: "npm:^1.3.1"
+    simple-concat: "npm:^1.0.0"
+  checksum: 10c0/b0649a581dbca741babb960423248899203165769747142033479a7dc5e77d7b0fced0253c731cd57cf21e31e4d77c9157c3069f4448d558ebc96cf9e1eebcf0
+  languageName: node
+  linkType: hard
+
+"slash@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "slash@npm:2.0.0"
+  checksum: 10c0/f83dbd3cb62c41bb8fcbbc6bf5473f3234b97fa1d008f571710a9d3757a28c7169e1811cad1554ccb1cc531460b3d221c9a7b37f549398d9a30707f0a5af9193
   languageName: node
   linkType: hard
 
@@ -4773,10 +6259,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"space-separated-tokens@npm:^1.0.0":
+  version: 1.1.5
+  resolution: "space-separated-tokens@npm:1.1.5"
+  checksum: 10c0/3ee0a6905f89e1ffdfe474124b1ade9fe97276a377a0b01350bc079b6ec566eb5b219e26064cc5b7f3899c05bde51ffbc9154290b96eaf82916a1e2c2c13ead9
+  languageName: node
+  linkType: hard
+
 "space-separated-tokens@npm:^2.0.0":
   version: 2.0.2
   resolution: "space-separated-tokens@npm:2.0.2"
   checksum: 10c0/6173e1d903dca41dcab6a2deed8b4caf61bd13b6d7af8374713500570aa929ff9414ae09a0519f4f8772df993300305a395d4871f35bc4ca72b6db57e1f30af8
+  languageName: node
+  linkType: hard
+
+"sprintf-js@npm:~1.0.2":
+  version: 1.0.3
+  resolution: "sprintf-js@npm:1.0.3"
+  checksum: 10c0/ecadcfe4c771890140da5023d43e190b7566d9cf8b2d238600f31bec0fc653f328da4450eb04bd59a431771a8e9cc0e118f0aa3974b683a4981b4e07abc2a5bb
   languageName: node
   linkType: hard
 
@@ -4823,6 +6323,13 @@ __metadata:
     stack-generator: "npm:^2.0.5"
     stacktrace-gps: "npm:^3.0.4"
   checksum: 10c0/9a10c222524ca03690bcb27437b39039885223e39320367f2be36e6f750c2d198ae99189869a22c255bf60072631eb609d47e8e33661e95133686904e01121ec
+  languageName: node
+  linkType: hard
+
+"stampit@npm:^4.3.2":
+  version: 4.3.2
+  resolution: "stampit@npm:4.3.2"
+  checksum: 10c0/27b6714633f90c263b6f74bee6b03ff5db14cc1e6e7bd0c467ce4b83ebc1ca82b27f8d4d68da7e8711444ff324b0510a7c2387742a2200bdd8cbf2520ffc5eb4
   languageName: node
   linkType: hard
 
@@ -4905,6 +6412,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"string_decoder@npm:^1.1.1":
+  version: 1.3.0
+  resolution: "string_decoder@npm:1.3.0"
+  dependencies:
+    safe-buffer: "npm:~5.2.0"
+  checksum: 10c0/810614ddb030e271cd591935dcd5956b2410dd079d64ff92a1844d6b7588bf992b3e1b69b0f4d34a3e06e0bd73046ac646b5264c1987b20d0601f81ef35d731d
+  languageName: node
+  linkType: hard
+
 "stringify-entities@npm:^4.0.0":
   version: 4.0.3
   resolution: "stringify-entities@npm:4.0.3"
@@ -4944,6 +6460,13 @@ __metadata:
   version: 3.1.1
   resolution: "strip-json-comments@npm:3.1.1"
   checksum: 10c0/9681a6257b925a7fa0f285851c0e613cc934a50661fa7bb41ca9cbbff89686bb4a0ee366e6ecedc4daafd01e83eee0720111ab294366fe7c185e935475ebcecd
+  languageName: node
+  linkType: hard
+
+"strip-json-comments@npm:~2.0.1":
+  version: 2.0.1
+  resolution: "strip-json-comments@npm:2.0.1"
+  checksum: 10c0/b509231cbdee45064ff4f9fd73609e2bcc4e84a4d508e9dd0f31f70356473fde18abfb5838c17d56fb236f5a06b102ef115438de0600b749e818a35fbbc48c43
   languageName: node
   linkType: hard
 
@@ -5020,6 +6543,74 @@ __metadata:
   languageName: node
   linkType: hard
 
+"swagger-client@npm:^3.25.3":
+  version: 3.25.3
+  resolution: "swagger-client@npm:3.25.3"
+  dependencies:
+    "@babel/runtime-corejs3": "npm:^7.22.15"
+    "@swagger-api/apidom-core": "npm:>=0.90.0 <1.0.0"
+    "@swagger-api/apidom-error": "npm:>=0.90.0 <1.0.0"
+    "@swagger-api/apidom-json-pointer": "npm:>=0.90.0 <1.0.0"
+    "@swagger-api/apidom-ns-openapi-3-1": "npm:>=0.90.0 <1.0.0"
+    "@swagger-api/apidom-reference": "npm:>=0.90.0 <1.0.0"
+    cookie: "npm:~0.6.0"
+    deepmerge: "npm:~4.3.0"
+    fast-json-patch: "npm:^3.0.0-1"
+    is-plain-object: "npm:^5.0.0"
+    js-yaml: "npm:^4.1.0"
+    node-abort-controller: "npm:^3.1.1"
+    node-fetch-commonjs: "npm:^3.3.2"
+    qs: "npm:^6.10.2"
+    traverse: "npm:~0.6.6"
+  checksum: 10c0/87bd2d70fe896792fbd61899b09cb4c6486a20e1f0fa852727065589219820eaa902b937fdf86db6130411f6c7542737fd9bc792b688d32c4853be3f32627fa8
+  languageName: node
+  linkType: hard
+
+"swagger-ui-react@npm:5.11.8":
+  version: 5.11.8
+  resolution: "swagger-ui-react@npm:5.11.8"
+  dependencies:
+    "@babel/runtime-corejs3": "npm:^7.23.9"
+    "@braintree/sanitize-url": "npm:=7.0.0"
+    base64-js: "npm:^1.5.1"
+    classnames: "npm:^2.5.1"
+    css.escape: "npm:1.5.1"
+    deep-extend: "npm:0.6.0"
+    dompurify: "npm:=3.0.9"
+    ieee754: "npm:^1.2.1"
+    immutable: "npm:^3.x.x"
+    js-file-download: "npm:^0.4.12"
+    js-yaml: "npm:=4.1.0"
+    lodash: "npm:^4.17.21"
+    patch-package: "npm:^8.0.0"
+    prop-types: "npm:^15.8.1"
+    randexp: "npm:^0.5.3"
+    randombytes: "npm:^2.1.0"
+    react-copy-to-clipboard: "npm:5.1.0"
+    react-debounce-input: "npm:=3.3.0"
+    react-immutable-proptypes: "npm:2.2.0"
+    react-immutable-pure-component: "npm:^2.2.0"
+    react-inspector: "npm:^6.0.1"
+    react-redux: "npm:^9.1.0"
+    react-syntax-highlighter: "npm:^15.5.0"
+    redux: "npm:^5.0.1"
+    redux-immutable: "npm:^4.0.0"
+    remarkable: "npm:^2.0.1"
+    reselect: "npm:^5.1.0"
+    serialize-error: "npm:^8.1.0"
+    sha.js: "npm:^2.4.11"
+    swagger-client: "npm:^3.25.3"
+    url-parse: "npm:^1.5.10"
+    xml: "npm:=1.0.1"
+    xml-but-prettier: "npm:^1.0.1"
+    zenscroll: "npm:^4.0.2"
+  peerDependencies:
+    react: ">=16.8.0 <19"
+    react-dom: ">=16.8.0 <19"
+  checksum: 10c0/845d6cfb8480d86d0705c54ef0a2baa0063b285197aa355c81e8f70bbae43d21d3811449f57e493d7979b4ae85623e789d84dd1c915ae9d4b1194778e4cfbf52
+  languageName: node
+  linkType: hard
+
 "swr@npm:2.2.5":
   version: 2.2.5
   resolution: "swr@npm:2.2.5"
@@ -5049,6 +6640,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tar-fs@npm:^2.0.0":
+  version: 2.1.1
+  resolution: "tar-fs@npm:2.1.1"
+  dependencies:
+    chownr: "npm:^1.1.1"
+    mkdirp-classic: "npm:^0.5.2"
+    pump: "npm:^3.0.0"
+    tar-stream: "npm:^2.1.4"
+  checksum: 10c0/871d26a934bfb7beeae4c4d8a09689f530b565f79bd0cf489823ff0efa3705da01278160da10bb006d1a793fa0425cf316cec029b32a9159eacbeaff4965fb6d
+  languageName: node
+  linkType: hard
+
+"tar-stream@npm:^2.1.4":
+  version: 2.2.0
+  resolution: "tar-stream@npm:2.2.0"
+  dependencies:
+    bl: "npm:^4.0.3"
+    end-of-stream: "npm:^1.4.1"
+    fs-constants: "npm:^1.0.0"
+    inherits: "npm:^2.0.3"
+    readable-stream: "npm:^3.1.1"
+  checksum: 10c0/2f4c910b3ee7196502e1ff015a7ba321ec6ea837667220d7bcb8d0852d51cb04b87f7ae471008a6fb8f5b1a1b5078f62f3a82d30c706f20ada1238ac797e7692
+  languageName: node
+  linkType: hard
+
 "tar@npm:^6.1.11, tar@npm:^6.1.2":
   version: 6.2.0
   resolution: "tar@npm:6.2.0"
@@ -5074,6 +6690,15 @@ __metadata:
   version: 3.0.1
   resolution: "throttle-debounce@npm:3.0.1"
   checksum: 10c0/c8e558479463b7ed8bac30d6b10cc87abd1c9fc64edfce2db4109be1a04acaef5d2d0557f49c1a3845ea07d9f79e6e0389b1b60db0a77c44e5b7a1216596f285
+  languageName: node
+  linkType: hard
+
+"tmp@npm:^0.0.33":
+  version: 0.0.33
+  resolution: "tmp@npm:0.0.33"
+  dependencies:
+    os-tmpdir: "npm:~1.0.2"
+  checksum: 10c0/69863947b8c29cabad43fe0ce65cec5bb4b481d15d4b4b21e036b060b3edbf3bc7a5541de1bacb437bb3f7c4538f669752627fdf9b4aaf034cebd172ba373408
   languageName: node
   linkType: hard
 
@@ -5110,6 +6735,7 @@ __metadata:
     "@types/papaparse": "npm:5.3.14"
     "@types/react": "npm:18.2.60"
     "@types/react-dom": "npm:18.2.19"
+    "@types/swagger-ui-react": "npm:4.18.3"
     axios: "npm:1.6.7"
     copy-to-clipboard: "npm:3.3.3"
     eslint: "npm:8.57.0"
@@ -5129,11 +6755,50 @@ __metadata:
     react-select: "npm:5.8.0"
     react-use: "npm:17.5.0"
     sass: "npm:1.71.1"
+    swagger-ui-react: "npm:5.11.8"
     swr: "npm:2.2.5"
     typescript: "npm:5.3.3"
     unplugin-auto-import: "npm:0.17.5"
   languageName: unknown
   linkType: soft
+
+"traverse@npm:~0.6.6":
+  version: 0.6.8
+  resolution: "traverse@npm:0.6.8"
+  checksum: 10c0/d97a71be2ca895ff6b813840db37f9b5d88e30f7c4c4bd5b22c5c68ebc22d4a10c4599e02c51414523cc7ada3432e118ea62ebd53cf6f3a4f3aa951bd45072a9
+  languageName: node
+  linkType: hard
+
+"tree-sitter-json@npm:=0.20.2":
+  version: 0.20.2
+  resolution: "tree-sitter-json@npm:0.20.2"
+  dependencies:
+    nan: "npm:^2.18.0"
+    node-gyp: "npm:latest"
+  checksum: 10c0/cbabe0ac875121219034d42e6174dfe5acf58c1314cf62e798dd53781e36d7427855157f629ca81902e23d8ddb9f9e0e15b6a922593cddeea69c3c5ee5235947
+  languageName: node
+  linkType: hard
+
+"tree-sitter-yaml@npm:=0.5.0":
+  version: 0.5.0
+  resolution: "tree-sitter-yaml@npm:0.5.0"
+  dependencies:
+    nan: "npm:^2.14.0"
+    node-gyp: "npm:latest"
+  checksum: 10c0/a93446ac64c294457d29c1ab826a63e196d445499702313eb1037f070e6c431fa653bcec10e1b4bf81af3710afff7138381c35109282bf41b3244b32015e6afe
+  languageName: node
+  linkType: hard
+
+"tree-sitter@npm:=0.20.4":
+  version: 0.20.4
+  resolution: "tree-sitter@npm:0.20.4"
+  dependencies:
+    nan: "npm:^2.17.0"
+    node-gyp: "npm:latest"
+    prebuild-install: "npm:^7.1.1"
+  checksum: 10c0/afcdc7d95b3ce114a3b569608ef9a0d26646c252d5059bc285d1863af1a1f74c74427f43292c1f6c2d1a6806b5c5d053862c0edc2f9d5f4725f887dbe4a6e5c3
+  languageName: node
+  linkType: hard
 
 "trim-lines@npm:^3.0.0":
   version: 3.0.1
@@ -5165,6 +6830,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-mixer@npm:^6.0.3":
+  version: 6.0.4
+  resolution: "ts-mixer@npm:6.0.4"
+  checksum: 10c0/4c442fc99cdffd4a3f0ce55c624fb703f4ded5cab6912f97705489565c4a74d3e4213f10c33499ec5150900a628d38537a9a6a9e35b5045b65129a84b4db21ae
+  languageName: node
+  linkType: hard
+
+"ts-toolbelt@npm:^9.6.0":
+  version: 9.6.0
+  resolution: "ts-toolbelt@npm:9.6.0"
+  checksum: 10c0/838f9a2f0fe881d5065257a23b402c41315b33ff987b73db3e2b39fcb70640c4c7220e1ef118ed5676763543724fdbf4eda7b0e2c17acb667ed1401336af9f8c
+  languageName: node
+  linkType: hard
+
 "tsconfig-paths@npm:^3.15.0":
   version: 3.15.0
   resolution: "tsconfig-paths@npm:3.15.0"
@@ -5177,10 +6856,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.6.2":
+"tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.4.0, tslib@npm:^2.6.2":
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
   checksum: 10c0/e03a8a4271152c8b26604ed45535954c0a45296e32445b4b87f8a5abdb2421f40b59b4ca437c4346af0f28179780d604094eb64546bee2019d903d01c6c19bdb
+  languageName: node
+  linkType: hard
+
+"tunnel-agent@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "tunnel-agent@npm:0.6.0"
+  dependencies:
+    safe-buffer: "npm:^5.0.1"
+  checksum: 10c0/4c7a1b813e7beae66fdbf567a65ec6d46313643753d0beefb3c7973d66fcec3a1e7f39759f0a0b4465883499c6dc8b0750ab8b287399af2e583823e40410a17a
   languageName: node
   linkType: hard
 
@@ -5244,6 +6932,15 @@ __metadata:
     for-each: "npm:^0.3.3"
     is-typed-array: "npm:^1.1.9"
   checksum: 10c0/c5163c0103d07fefc8a2ad0fc151f9ca9a1f6422098c00f695d55f9896e4d63614cd62cf8d8a031c6cee5f418e8980a533796597174da4edff075b3d275a7e23
+  languageName: node
+  linkType: hard
+
+"types-ramda@npm:^0.29.7":
+  version: 0.29.8
+  resolution: "types-ramda@npm:0.29.8"
+  dependencies:
+    ts-toolbelt: "npm:^9.6.0"
+  checksum: 10c0/325dd96b402fb4bab9d5bb13785ddbec3a3a19e8eba3ee87f07ebbd9f9f3a5074e394c82e2dfdae3e8791fd807b81c71d7ad9c4ece3b39999243f5ec82506895
   languageName: node
   linkType: hard
 
@@ -5405,6 +7102,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"universalify@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "universalify@npm:2.0.1"
+  checksum: 10c0/73e8ee3809041ca8b818efb141801a1004e3fc0002727f1531f4de613ea281b494a40909596dae4a042a4fb6cd385af5d4db2e137b1362e0e91384b828effd3a
+  languageName: node
+  linkType: hard
+
 "unplugin-auto-import@npm:0.17.5":
   version: 0.17.5
   resolution: "unplugin-auto-import@npm:0.17.5"
@@ -5441,12 +7145,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unraw@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "unraw@npm:3.0.0"
+  checksum: 10c0/cd1e7a961c8dc075bdf07300bc046da6bc8c4f1b88c68191c392520f0c64914fa783d48f2431c668f79b1afbd4bab16e864c7aca3cc06ddc94567c1fec114b43
+  languageName: node
+  linkType: hard
+
 "uri-js@npm:^4.2.2":
   version: 4.4.1
   resolution: "uri-js@npm:4.4.1"
   dependencies:
     punycode: "npm:^2.1.0"
   checksum: 10c0/4ef57b45aa820d7ac6496e9208559986c665e49447cb072744c13b66925a362d96dd5a46c4530a6b8e203e5db5fe849369444440cb22ecfc26c679359e5dfa3c
+  languageName: node
+  linkType: hard
+
+"url-parse@npm:^1.5.10":
+  version: 1.5.10
+  resolution: "url-parse@npm:1.5.10"
+  dependencies:
+    querystringify: "npm:^2.1.1"
+    requires-port: "npm:^1.0.0"
+  checksum: 10c0/bd5aa9389f896974beb851c112f63b466505a04b4807cea2e5a3b7092f6fbb75316f0491ea84e44f66fed55f1b440df5195d7e3a8203f64fcefa19d182f5be87
   languageName: node
   linkType: hard
 
@@ -5462,12 +7183,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-sync-external-store@npm:^1.2.0":
+"use-sync-external-store@npm:^1.0.0, use-sync-external-store@npm:^1.2.0":
   version: 1.2.0
   resolution: "use-sync-external-store@npm:1.2.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
   checksum: 10c0/ac4814e5592524f242921157e791b022efe36e451fe0d4fd4d204322d5433a4fc300d63b0ade5185f8e0735ded044c70bcf6d2352db0f74d097a238cebd2da02
+  languageName: node
+  linkType: hard
+
+"util-deprecate@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "util-deprecate@npm:1.0.2"
+  checksum: 10c0/41a5bdd214df2f6c3ecf8622745e4a366c4adced864bc3c833739791aeeeb1838119af7daed4ba36428114b5c67dcda034a79c882e97e43c03e66a4dd7389942
   languageName: node
   linkType: hard
 
@@ -5489,6 +7217,20 @@ __metadata:
     unist-util-stringify-position: "npm:^4.0.0"
     vfile-message: "npm:^4.0.0"
   checksum: 10c0/443bda43e5ad3b73c5976e987dba2b2d761439867ba7d5d7c5f4b01d3c1cb1b976f5f0e6b2399a00dc9b4eaec611bd9984ce9ce8a75a72e60aed518b10a902d2
+  languageName: node
+  linkType: hard
+
+"web-streams-polyfill@npm:^3.0.3":
+  version: 3.3.3
+  resolution: "web-streams-polyfill@npm:3.3.3"
+  checksum: 10c0/64e855c47f6c8330b5436147db1c75cb7e7474d924166800e8e2aab5eb6c76aac4981a84261dd2982b3e754490900b99791c80ae1407a9fa0dcff74f82ea3a7f
+  languageName: node
+  linkType: hard
+
+"web-tree-sitter@npm:=0.20.3":
+  version: 0.20.3
+  resolution: "web-tree-sitter@npm:0.20.3"
+  checksum: 10c0/5555d1d44a21c5dd5cbfa0aa2e277dcf030e655d1302caaceb9496eae12fc1a77ccf0eb20b4b06a459dbc83869893c5a94f1d13d83279769588dce8136d0cc32
   languageName: node
   linkType: hard
 
@@ -5615,6 +7357,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"xml-but-prettier@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "xml-but-prettier@npm:1.0.1"
+  dependencies:
+    repeat-string: "npm:^1.5.2"
+  checksum: 10c0/d493d7bf0f9f94faa9e6e142355045cbab10593770fa1a5e502369169f4abb1ab7ff134194f7de501ccebfe0f440a72b97363b1ad55172d3cd21fc2eab0b7ce9
+  languageName: node
+  linkType: hard
+
+"xml@npm:=1.0.1":
+  version: 1.0.1
+  resolution: "xml@npm:1.0.1"
+  checksum: 10c0/04bcc9b8b5e7b49392072fbd9c6b0f0958bd8e8f8606fee460318e43991349a68cbc5384038d179ff15aef7d222285f69ca0f067f53d071084eb14c7fdb30411
+  languageName: node
+  linkType: hard
+
+"xtend@npm:^4.0.0":
+  version: 4.0.2
+  resolution: "xtend@npm:4.0.2"
+  checksum: 10c0/366ae4783eec6100f8a02dff02ac907bf29f9a00b82ac0264b4d8b832ead18306797e283cf19de776538babfdcb2101375ec5646b59f08c52128ac4ab812ed0e
+  languageName: node
+  linkType: hard
+
 "yallist@npm:^4.0.0":
   version: 4.0.0
   resolution: "yallist@npm:4.0.0"
@@ -5629,10 +7394,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yaml@npm:^2.2.2":
+  version: 2.4.0
+  resolution: "yaml@npm:2.4.0"
+  bin:
+    yaml: bin.mjs
+  checksum: 10c0/97ab0b5a0714c92e4dd75120a6a63e470b0adc282afae0a701bf38f8c42cbf6429fcd6aca883e3a63c68936ab841862e6c69e2d66d355c3e4fc7cfd346af2108
+  languageName: node
+  linkType: hard
+
 "yocto-queue@npm:^0.1.0":
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: 10c0/dceb44c28578b31641e13695d200d34ec4ab3966a5729814d5445b194933c096b7ced71494ce53a0e8820685d1d010df8b2422e5bf2cdea7e469d97ffbea306f
+  languageName: node
+  linkType: hard
+
+"zenscroll@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "zenscroll@npm:4.0.2"
+  checksum: 10c0/419e87ebe3a22a3b2ac22cd02aeccb900c9c330f539efdb1efc382090157d466373ee615812caef5bbe2da140e3c7df222236c8cfd8e697e97d4d91cf3f81c63
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
swaggerの中身を移植し、`swagger 2.0`用の表記であった部分を`openapi 3.0.0`用に書き直しました