### PR TITLE
#132対応：レイアウト調整

### DIFF
--- a/src/components/Datasets.tsx
+++ b/src/components/Datasets.tsx
@@ -87,21 +87,19 @@ const Datasets = ({ executeExamples }: Props) => {
                     />
                     <section className="database__index__links">
                       {nameIndex.map((v, i) => (
-                        <span key={i}>
-                          {i > 0 && ", "}
-                          <span
-                            style={{ cursor: "pointer" }}
-                            onClick={() => handleNameIndexFilter(v)}
-                            className={
-                              searchCategorySetList.size === 0 ||
-                              searchCategorySetList.has(v)
-                                ? "text active"
-                                : "text"
-                            }
-                          >
-                            {v}
-                          </span>
-                        </span>
+                        <button
+                          key={i}
+                          onClick={() => handleNameIndexFilter(v)}
+                          aria-current={searchNameIndexSetList.has(v)}
+                          className={
+                            searchCategorySetList.size === 0 ||
+                            searchCategorySetList.has(v)
+                              ? "text active"
+                              : "text"
+                          }
+                        >
+                          {v}
+                        </button>
                       ))}
                     </section>
                   </section>

--- a/src/components/Datasets.tsx
+++ b/src/components/Datasets.tsx
@@ -90,10 +90,9 @@ const Datasets = ({ executeExamples }: Props) => {
                         <button
                           key={i}
                           onClick={() => handleNameIndexFilter(v)}
-                          aria-current={searchNameIndexSetList.has(v)}
                           className={
-                            searchCategorySetList.size === 0 ||
-                            searchCategorySetList.has(v)
+                            searchNameIndexSetList.size === 0 ||
+                            searchNameIndexSetList.has(v)
                               ? "text active"
                               : "text"
                           }

--- a/src/styles/_index.scss
+++ b/src/styles/_index.scss
@@ -398,6 +398,29 @@
       padding: 17px;
       border-radius: 10px;
       background-color: g.$col-FFF;
+
+      .clear-button {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 0;
+        margin: 20px 0 0 auto;
+        border: none;
+        background-color: unset;
+
+        &__icon {
+          width: 11px;
+          height: 11px;
+        }
+
+        &__text {
+          font: {
+            family: g.$ff-oswald;
+            size: 1.6rem;
+            weight: 300;
+          }
+        }
+      }
     }
 
     &__keyword {

--- a/src/styles/_index.scss
+++ b/src/styles/_index.scss
@@ -241,7 +241,7 @@
                 display: grid;
                 gap: 4px;
                 grid-template-columns: 1fr 18px;
-                min-width: 150px;
+                width: 150px;
                 font: {
                   family: g.$ff-oswald;
                   size: 1.2rem;

--- a/src/styles/_index.scss
+++ b/src/styles/_index.scss
@@ -398,6 +398,28 @@
       padding: 17px;
       border-radius: 10px;
       background-color: g.$col-FFF;
+      &:has(.text[aria-current="true"]) {
+        .text {
+          color: g.$col-C4C4C4;
+
+          &[aria-current="true"] {
+            color: g.$col-000;
+          }
+        }
+      }
+
+      .text {
+        cursor: pointer;
+        padding: 0;
+        border: unset;
+        background-color: unset;
+
+        &:not(:last-of-type) {
+          &::after {
+            content: ", ";
+          }
+        }
+      }
 
       .clear-button {
         display: flex;
@@ -486,6 +508,7 @@
 
       &__links {
         display: flex;
+        gap: 5px;
 
         a {
           font-family: g.$ff-oswald;

--- a/src/styles/_index.scss
+++ b/src/styles/_index.scss
@@ -398,26 +398,22 @@
       padding: 17px;
       border-radius: 10px;
       background-color: g.$col-FFF;
-      &:has(.text[aria-current="true"]) {
-        .text {
-          color: g.$col-C4C4C4;
-
-          &[aria-current="true"] {
-            color: g.$col-000;
-          }
-        }
-      }
 
       .text {
         cursor: pointer;
         padding: 0;
         border: unset;
         background-color: unset;
+        color: g.$col-C4C4C4;
 
         &:not(:last-of-type) {
           &::after {
             content: ", ";
           }
+        }
+
+        &.active {
+          color: g.$col-000;
         }
       }
 


### PR DESCRIPTION
## 解決
resolved #132 

## 概要
### DATASETSタブのアクティブな要素の表示について
- HTMLの構造を変更しました。（`<span>`の入れ子になっていたものを`<button>`のみに変更）
- アクティブなものはクラス名で判別できるのかと思ったのですが、常に`.active`だった為、こちらのクラス名は使用しておりません。
- `<button>`に`aria-current`属性を追加し、値には`searchCategorySetList.has(v)`を設定しました。
- 色見は「Color Legend」と同じにしています。

![FireShot Capture 110 - TogoID - localhost](https://github.com/togoid/togoid-converter/assets/22611766/576e74a1-e267-4c74-afb6-a84eb5305764)

