### PR TITLE
Resultsモーダル内のdetailにmax-heightを設定

### DIFF
--- a/src/components/ResultModalActionTable.tsx
+++ b/src/components/ResultModalActionTable.tsx
@@ -165,7 +165,7 @@ const ResultModalActionTable = ({
                         <input
                           id={`showLabels${i}`}
                           type="checkbox"
-                          className="checkbox"
+                          className="small-checkbox"
                           checked={tableHead.annotateList[0].checked}
                           onChange={(e) =>
                             updateAnnotateChecked(

--- a/src/styles/_modal.scss
+++ b/src/styles/_modal.scss
@@ -360,7 +360,9 @@
             display: flex;
             gap: 8px;
             flex-direction: column;
+            max-height: 15vh;
             padding: 16px;
+            overflow-y: auto;
             border-radius: 5px;
             border: 1px solid g.$col-D5D5D5;
             background-color: g.$col-FFF;
@@ -420,7 +422,7 @@
           }
         }
 
-        .checkbox {
+        .small-checkbox {
           @include g.visuallyHidden;
 
           &:checked {


### PR DESCRIPTION
https://github.com/togoid/togoid-converter/issues/189#issuecomment-2900098718

項目が少ない時の表示が少し間抜けになってしまうため、高さは一定ではなく、`max-height`（最大値）を設定し、中身がそれ以上に長くなる場合は、スクロールが発生するようにしました。